### PR TITLE
Handle non-parseable values in attributes

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -485,9 +485,17 @@ class Reader:
                 if value == b(''):
                     value = 0
                 elif deci:
-                    value = float(value)
+                    try:
+                        value = float(value)
+                    except ValueError:
+                        #not parseable as float, set to None
+                        value = None
                 else:
-                    value = int(value)
+                    try:
+                        value = int(value)
+                    except ValueError:
+                        #not parseable as int, set to None
+                        value = None
             elif typ == b('D'):
                 try:
                     y, m, d = int(value[:4]), int(value[4:6]), int(value[6:8])


### PR DESCRIPTION
For shapefiles with values that cannot be cast to float or int in the attributes the lib dies with a ValueError. I think it's cleaner to then set the value to None. This is consistent with how QGIS handles these shapefiles and should not cause much trouble. 

If this causes trouble it's possible to add a flag to either die on error or set to None.