### PR TITLE
Don't Use Asserts For Runtime Errors

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -453,7 +453,8 @@ class Reader:
             fieldDesc[1] = u(fieldDesc[1])
             self.fields.append(fieldDesc)
         terminator = dbf.read(1)
-        assert terminator == b("\r")
+        if terminator != b("\r"):
+            raise ShapefileException("Shapefile dbf header lacks expected terminator. (likely corrupt?)")
         self.fields.insert(0, ('DeletionFlag', 'C', 1, 0))
 
     def __recordFmt(self):
@@ -888,7 +889,10 @@ class Writer:
                     value = str(value)[0].upper()
                 else:
                     value = str(value)[:size].ljust(size)
-                assert len(value) == size
+                if len(value) != size:
+                    raise ShapefileException(
+                        "Shapefile Writer unable to pack incorrect sized value"
+                        " (size %d) into field '%s' (size %d)." % (len(value), fieldName, size))
                 value = b(value)
                 f.write(value)
 


### PR DESCRIPTION
While pyshp is generally good about raising appropriate exceptions, it currently uses `assert()` in two places:

* Possibly corrupted DBF header
* User attempting to write larger value than a field allows for

Not only are these both examples of cases where `assert()` isn't appropriate, they're cases that could lead to data corruption if uncaught... and when CPython is invoked with -O or -OO, `assert()` conditions are never raised.

This patch raises a descriptive ShapefileException in these two cases.