### PR TITLE
Seamlessly Read/Write `datetime.date` Objects

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -15,6 +15,7 @@ import sys
 import time
 import array
 import tempfile
+from datetime import date
 
 #
 # Constants for shape types
@@ -473,8 +474,7 @@ class Reader:
             # deleted record
             return None
         record = []
-        for (name, typ, size, deci), value in zip(self.fields,
-                                                                                                recordContents):
+        for (name, typ, size, deci), value in zip(self.fields, recordContents):
             if name == 'DeletionFlag':
                 continue
             elif not value.strip():
@@ -491,7 +491,7 @@ class Reader:
             elif typ == b('D'):
                 try:
                     y, m, d = int(value[:4]), int(value[4:6]), int(value[6:8])
-                    value = [y, m, d]
+                    value = date(y, m, d)
                 except:
                     value = value.strip()
             elif typ == b('L'):
@@ -882,10 +882,12 @@ class Writer:
             for (fieldName, fieldType, size, dec), value in zip(self.fields, record):
                 fieldType = fieldType.upper()
                 size = int(size)
-                if fieldType.upper() == "N":
+                if fieldType == 'N':
                     value = str(value).rjust(size)
                 elif fieldType == 'L':
                     value = str(value)[0].upper()
+                elif fieldType == 'D' and isinstance(value, date):
+                    value = value.strftime('%Y%m%d').ljust(size)
                 else:
                     value = str(value)[:size].ljust(size)
                 assert len(value) == size
@@ -939,9 +941,18 @@ class Writer:
             polyShape.partTypes = partTypes
         self._shapes.append(polyShape)
 
-    def field(self, name, fieldType="C", size="50", decimal=0):
+    def field(self, name, fieldType='C', size=50, decimal=0):
         """Adds a dbf field descriptor to the shapefile."""
+        fieldType = fieldType.upper()
+        size = int(size)
+        decimal = int(decimal)
+        if fieldType == 'D' and size < 8:
+            raise ShapefileException("Date fields require min size of 8 (%d is too small)" % size)
         self.fields.append((name, fieldType, size, decimal))
+
+    def fieldDate(self, name):
+        """Adds a Date type dbf descriptor to the shapefile"""
+        self.field(name, 'D', 8, 0)
 
     def record(self, *recordList, **recordDict):
         """Creates a dbf attribute record. You can submit either a sequence of

--- a/tests/date_tests.py
+++ b/tests/date_tests.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for Pythonic `datetime.date` object handling.
+"""
+
+import unittest
+import datetime
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import BytesIO as StringIO
+
+import shapefile
+
+
+class TestDateHandling(unittest.TestCase):
+
+    def testDateReadWrite(self):
+        """Round-trip read and write Python `date` as value for 'D' field"""
+        today = datetime.date.today()
+
+        # Write a one-field, one-record shp to memory; use `date` obj as value
+        writer = shapefile.Writer()
+        writer.field('DATEFIELD', 'D', 8)
+        writer.null()
+        writer.record(today)
+        shp, shx, dbf = StringIO(), StringIO(), StringIO()
+        writer.save(shp=shp, shx=shx, dbf=dbf)
+
+        # Read our in-memory shp to verify that Reader gives us a `date` obj
+        reader = shapefile.Reader(shp=shp, shx=shx, dbf=dbf)
+        self.assertEqual(reader.fields[-1][1], 'D')
+        self.assertEqual(len(reader.records()), 1)
+        record = reader.record(0)
+        d = record[0]
+        self.assertTrue(isinstance(d, datetime.date),
+                        "Expected a `date` object back from Reader (we got a %s)" % type(d))
+        self.assertEqual(d, today)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Pyshp's API is able to cast Python string/byte/unicode values, as well as numeric values. Its handling of Date fields is not so seamless. Users are expected to write exactly eight characters in YYYYMMDD format, then get handed a tuple of [year, month, day] ints when reading.

This patch allows writing values as `datetime.date` (or any subclass, eg. `datetime.datetime`). It also maintains backwards compatibility allowing the user to write a string value. It changes reading behavior, however, in that it now passes back a `datetime.date` object rather than a [year, month, day] int tuple. Reader does not handle NULL date fields, because I didn't want to clobber the patch I submitted with PR https://github.com/GeospatialPython/pyshp/pull/16 ; so I'll note here that this code will raise an exception when reading a 'D' field with value "00000000" - I can amend this PR if you prefer.

This PR also adds a helper function `Writer.fieldDate(name)` so that users don't need to care about the underlying dBase storage whatsoever. I'd be happy to contribute more helper functions like this for other typical data types if you like.

A unit test is included; however I used the Python 2.1+ standard library's 'unittest' framework rather than grafting more doctests to the README file. Documentation has not been updated.