### PR TITLE
Add Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  
+  
+install: pip install .
+  
+script: python shapefile.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - dos2unix
+
 language: python
+
 python:
   - "2.6"
   - "2.7"
@@ -10,6 +16,8 @@ python:
   - "3.5"
   
   
-install: pip install .
+install: 
+  - dos2unix README.txt
+  - pip install .
   
 script: python shapefile.py

--- a/README.txt
+++ b/README.txt
@@ -295,9 +295,9 @@ The blockgroup key and population count:
 
 There is also an iterShapeRecords() method to iterate through large files:
 
->>> shapeRecs = sf.iterShapeRecords()
->>> for shape, rec in shapeRecs:
-...     # do something here
+>> shapeRecs = sf.iterShapeRecords()
+>> for shape, rec in shapeRecs:
+..     # do something here
 
 Writing Shapefiles
 ++++++++++++++++++

--- a/shapefile.py
+++ b/shapefile.py
@@ -1193,4 +1193,6 @@ if __name__ == "__main__":
     testing libraries but for now unit testing is done using what's available in
     2.3.
     """
-    return test()
+    failure_count = test()
+    sys.exit(failure_count)
+    

--- a/shapefile.py
+++ b/shapefile.py
@@ -1183,7 +1183,8 @@ class Editor(Writer):
 def test():
     import doctest
     doctest.NORMALIZE_WHITESPACE = 1
-    doctest.testfile("README.txt", verbose=1)
+    failure_count, test_count = doctest.testfile("README.txt", verbose=1)
+    return failure_count
 
 if __name__ == "__main__":
     """
@@ -1192,4 +1193,4 @@ if __name__ == "__main__":
     testing libraries but for now unit testing is done using what's available in
     2.3.
     """
-    test()
+    return test()


### PR DESCRIPTION
This adds Travis-CI support.  You will have to login to https://travis-ci.org/ to enable Travis.

Code was added to shapefile.py to return a status on exit (0 success, anything else is failure). This was needed to work on Travis.

This takes 2 minutes to run and makes sure the the submitted code runs on the doctests.

dos2unix converts newline characters from dos format to unix format.  This caused problems for many python versions.

~~iterShapeRecords() was removed from doctests because it isn't a valid doctest.~~