### PR TITLE
Add empty record when calling w.record() with no arguments

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -1001,6 +1001,9 @@ class Writer:
                         record.append("")
                     else:
                         record.append(val)
+        else:
+            # Blank fields for empty record
+            record = ["" for i in range(fieldCount)]
         if record:
             self.records.append(record)
 


### PR DESCRIPTION
Previously, callling `w.record()` had no effect, leading to unbalanced shapefiles.