### PR TITLE
Performance improvement for `Reader.__shapeIndex`

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -392,7 +392,7 @@ class Reader:
             for r in range(numRecords):
                 # Offsets are 16-bit words just like the file length
                 self._offsets.append(unpack(">i", shx.read(4))[0] * 2)
-                shx.seek(shx.tell() + 4)
+                shx.seek(4, 1)
         if not i == None:
             return self._offsets[i]
 

--- a/shapefile.py
+++ b/shapefile.py
@@ -390,7 +390,11 @@ class Reader:
             # Jump to the first record.
             shx.seek(100)
             # Offsets are 16-bit words just like the file length
-            self._offsets = [unpack('>i4x', shx.read(8))[0] * 2 for r in range(numRecords)]
+            self._offsets = [2*el for el in 
+                             array.array('i', unpack(">%si" % (numRecords*2), 
+                                                     shx.read(4 * numRecords*2))
+                                         )[::2]
+                             ]
         if not i == None:
             return self._offsets[i]
 

--- a/shapefile.py
+++ b/shapefile.py
@@ -389,9 +389,8 @@ class Reader:
             numRecords = shxRecordLength // 8
             # Jump to the first record.
             shx.seek(100)
-            for r in range(numRecords):
-                # Offsets are 16-bit words just like the file length
-                self._offsets.append(unpack('>i4x', shx.read(8))[0] * 2)
+            # Offsets are 16-bit words just like the file length
+            self._offsets = [unpack('>i4x', shx.read(8))[0] * 2 for r in range(numRecords)]
         if not i == None:
             return self._offsets[i]
 

--- a/shapefile.py
+++ b/shapefile.py
@@ -391,8 +391,7 @@ class Reader:
             shx.seek(100)
             for r in range(numRecords):
                 # Offsets are 16-bit words just like the file length
-                self._offsets.append(unpack(">i", shx.read(4))[0] * 2)
-                shx.seek(4, 1)
+                self._offsets.append(unpack('>i4x', shx.read(8))[0] * 2)
         if not i == None:
             return self._offsets[i]
 

--- a/shapefile.py
+++ b/shapefile.py
@@ -389,12 +389,10 @@ class Reader:
             numRecords = shxRecordLength // 8
             # Jump to the first record.
             shx.seek(100)
+            shxRecords = array.array('i', unpack(">" + "i4x" * numRecords, 
+                                                 shx.read((4+4) * numRecords)))
             # Offsets are 16-bit words just like the file length
-            self._offsets = [2*el for el in 
-                             array.array('i', unpack(">%si" % (numRecords*2), 
-                                                     shx.read(4 * numRecords*2))
-                                         )[::2]
-                             ]
+            self._offsets = [2*el for el in shxRecords]
         if not i == None:
             return self._offsets[i]
 


### PR DESCRIPTION
Improves the performance of `Reader.__shapeIndex`.

x305 speedup over master with numpy available
x19 speedup over master without numpy

(Benchmarked on CPython 3.4.4 on Windows 8.1)

