### PR TITLE
Allow generation of empty (zero record) shapefile

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -675,6 +675,8 @@ class Writer:
     def __bbox(self, shapes, shapeTypes=[]):
         x = []
         y = []
+        if not shapes:
+            return [0, 0, 0, 0]
         for s in shapes:
             shapeType = self.shapeType
             if shapeTypes:
@@ -686,6 +688,8 @@ class Writer:
 
     def __zbox(self, shapes, shapeTypes=[]):
         z = []
+        if not shapes:
+            return [0, 0]
         for s in shapes:
             try:
                 for p in s.points:
@@ -697,6 +701,8 @@ class Writer:
 
     def __mbox(self, shapes, shapeTypes=[]):
         m = [0]
+        if not shapes:
+            return [0, 0]
         for s in shapes:
             try:
                 for p in s.points:


### PR DESCRIPTION
We are using pyshp inside NOAA for a project involving NWS weather warnings, and we had a requirement that if there are no active warnings, we should generate an empty shapefile. Currently pyshp errors on this case while trying to determine extents. This adds a sanity check and sets the extents to all zeroes if there are no shapes in the file.
