### PR TITLE
Add MANIFEST.in to include more files in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.md *.txt *.TXT
+recursive-include shapefiles *.dbf *.sbn *.sbx *.shp *.shx


### PR DESCRIPTION
With pattern in the `MANIFEST.in` file `python setup.py sdist` will include most files included in the git repository (the travis config is skipped).

See: https://docs.python.org/2/distutils/sourcedist.html#manifest

Fixes: #63 & #38
