### PR TITLE
Add Travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: python
+
 python:
-- '2.7'
+  - '2.7'
+  - '3.3'
+  - '3.4'
+  - '3.5'
+
+install:
+  - pip install .
+
 script:
-- touch foo
+  - python shapefile.py
+
 deploy:
   provider: pypi
   user: jlawhead

--- a/shapefile.py
+++ b/shapefile.py
@@ -1190,11 +1190,13 @@ class Editor(Writer):
         fieldName.replace(' ', '_')
 
 # Begin Testing
-def test():
+def test(**kwargs):
     import doctest
     doctest.NORMALIZE_WHITESPACE = 1
-    doctest.testfile("README.md", verbose=1)
-
+    verbosity = kwargs.get('verbose', 1)
+    failure_count, test_count = doctest.testfile("README.md", verbose=verbosity)
+    return failure_count
+    
 if __name__ == "__main__":
     """
     Doctests are contained in the file 'README.md'. This library was originally developed
@@ -1202,4 +1204,5 @@ if __name__ == "__main__":
     testing libraries but for now unit testing is done using what's available in
     2.3.
     """
-    test()
+    failure_count = test()
+    sys.exit(failure_count)


### PR DESCRIPTION
[This is current failing](https://travis-ci.org/micahcochran/pyshp/builds/155648216) until PR #68 is (or some similar solution) has been merged.  It is good that it is failing because it shows that there is a problem running the doctests.

If PR #68 gets merged (or some similar solution), this issue can be closed and reopened to rerun Travis tests.

I added a few small changes so that the number of failures gets reported to the status code.  Any status code that is zero (0) is Travis considers a success, anything other status code  is a failure.  (In this case the status code is 5 because 5 tests fail.) Also, added that verbosity can be turned off from the function.  So, you can quietly run the doctests by calling `shapefile.test(verbose=False)`.