### PR TITLE
Fix file-like objects without seek support not working

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -221,6 +221,12 @@ class Reader:
     within each file is only accessed when required and as
     efficiently as possible. Shapefiles are usually not large
     but they can be.
+
+    If initializing the reader with a file-like object which
+    does not support seek(), you must set allow_copy=True
+    to allow the Reader to copy the entire file in memory.
+    This is set to False by default in order to avoid
+    large files being copyied into memory without user intention.
     """
     def __init__(self, *args, **kwargs):
         self.shp = None


### PR DESCRIPTION
This is the revised version of https://github.com/GeospatialPython/pyshp/pull/80

Currently the `Reader` constructor checks if `hasattr(shp, "seek")`. If not, then `seek(0)` is not called - however, the other functions in the `Reader` class will call `seek()` in any case, so it doesn't make sense to avoid calling `seek()` here.

This PR fixes this by introducing a new argument to `Reader.__init__` (`allow_copy`). If this is set to `True`, the code will initialize a `io.BytesIO` with the file-like object's content.

Docs for `allow_copy`:

```
    If initializing the reader with a file-like object which
    does not support seek(), you must set allow_copy=True
    to allow the Reader to copy the entire file in memory.
    This is set to False by default in order to avoid
    large files being copyied into memory without user intention.
```

One usecase where this is useful is to support reading directly from a ZIP file without unzipping, because the file-likes which can be opened using the standard python `zipfile` library derive from `io.BufferedIOBase` which raises `io.UnsupportedOperation` when calling `seek()`.