### PR TITLE
fixed shape file component detection

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -275,7 +275,7 @@ class Reader:
                 self.dbf = open("%s.dbf" % shapeName, "rb")
             except IOError:
                 pass
-            if not (self.shp or self.dbf):
+            if not (self.shp and self.dbf):
                 raise ShapefileException("Unable to open %s.dbf or %s.shp." % (shapeName, shapeName) )
         if self.shp:
             self.__shpHeader()


### PR DESCRIPTION
I noticed that the was an `or` here where there should have been an `and`. 

Looking forward to a new release where `shapefile.Reader('./file')` works without `.shx`.