### PR TITLE
Stop zero from sneaking into mbox calculation

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -713,13 +713,14 @@ class Writer:
         return [min(z), max(z)]
 
     def __mbox(self, shapes):
-        m = [0]
+        m = []
         for s in shapes:
             try:
                 for p in s.points:
                     m.append(p[3])
             except IndexError:
                 pass
+        if not m: m.append(0)
         return [min(m), max(m)]
 
     def bbox(self):


### PR DESCRIPTION
Changed the mbox calculation to use same structure as zbox, while preserving the intent of setting mbox to zeros in case of no m values. 

In the previous implementation the list of m values was instantiated with a zero, presumably to set an mbox of zeros in case of no m values, but this would eg force the mbox to be 0-30 in a case where the true range was 15-30. Unless there is something I don't know about m values, this should not be the case.