### PR TITLE
Remove test verbosity and add Readme Travis CI testing status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# PyShp
+
+This library reads and writes ESRI Shapefiles in pure Python.
+
+[![Build Status](https://travis-ci.org/GeospatialPython/pyshp.svg?branch=master)](https://travis-ci.org/GeospatialPython/pyshp)
+
 ## Contents
 
 [Overview](#overview)

--- a/shapefile.py
+++ b/shapefile.py
@@ -1245,8 +1245,12 @@ class Editor(Writer):
 def test(**kwargs):
     import doctest
     doctest.NORMALIZE_WHITESPACE = 1
-    verbosity = kwargs.get('verbose', 1)
+    verbosity = kwargs.get('verbose', 0)
+    if verbosity == 0:
+        print('Running doctests...')
     failure_count, test_count = doctest.testfile("README.md", verbose=verbosity)
+    if verbosity == 0 and failure_count == 0:
+        print('All test passed successfully')
     return failure_count
     
 if __name__ == "__main__":


### PR DESCRIPTION
Default test verbosity to False to make it easier to spot the test failures. Partially fixes #54.