### PR TITLE
fix __geo_interface__ if parts or points is empty list

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -201,6 +201,11 @@ class Shape:
 
     @property
     def __geo_interface__(self):
+
+        """  Case parts or points is empty """
+        if not self.parts or not self.points:
+            return False
+        
         if self.shapeType in [POINT, POINTM, POINTZ]:
             return {
             'type': 'Point',


### PR DESCRIPTION
Fixes **UnboundLocalError** when shapes have empty parts or points

`  File "/usr/local/lib/python2.7/site-packages/shapefile.py", line 174, in __geo_interface__
    coordinates.append(tuple([tuple(p) for p in self.points[part:]]))
UnboundLocalError: local variable 'part' referenced before assignment`



