### PR TITLE
Add close method to Reader

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -373,6 +373,20 @@ class Reader:
         if self.dbf:
             self.__dbfHeader()
 
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        try:
+            if hasattr(self.shp, 'close'):
+                self.shp.close()
+            if hasattr(self.shx, 'close'):
+                self.shx.close()
+            if hasattr(self.dbf, 'close'):
+                self.dbf.close()
+        except IOError:
+            pass
+
     def __getFileObj(self, f):
         """Checks to see if the requested shapefile file object is
         available. If not a ShapefileException is raised."""


### PR DESCRIPTION
Some testing frameworks and other utilities will print a warning when files are left open at the end of a test. I've added a `close` method to the `Reader` class that closes any files that may have been opened. This `close` method is also called from `__del__` if the `Reader` object is deleted/garbage collected. The warning I was getting is:

```
  s = shapefile.Reader(shapefilename)
my_code.py:688: ResourceWarning: unclosed file <_io.BufferedReader name='my_shape.shx'>
```

I'm not super familiar with the internals of `Reader` so there could be a chance that this could break anything returned by the `Reader` that references `shp`, `shx`, and `dbf` files and depends on them staying open.