### PR TITLE
Added full encoding read/write support

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -1098,7 +1098,7 @@ class Writer:
                 value = b(value, self.encoding, self.encodingErrors)[:size].ljust(size)
             if not isinstance(value, bytes):
                 # just in case some of the numeric format() and date strftime() results are still in unicode (Python 3 only)
-                value = bytes(value) # should be default bytes ascii encoding
+                value = b(value, 'ascii', self.encodingErrors) # should be default ascii encoding
             if len(value) != size:
                 raise ShapefileException(
                     "Shapefile Writer unable to pack incorrect sized value"

--- a/shapefile.py
+++ b/shapefile.py
@@ -64,10 +64,10 @@ if PYTHON3:
             # Error.
             raise Exception('Unknown input type')
 
-    def u(v, encoding='utf-8'):
+    def u(v, encoding='utf-8', encodingErrors='strict'):
         if isinstance(v, bytes):
             # For python 3 decode bytes to str.
-            return v.decode(encoding)
+            return v.decode(encoding, encodingErrors)
         elif isinstance(v, str):
             # Already str.
             return v
@@ -301,6 +301,7 @@ class Reader:
         self.fields = []
         self.__dbfHdrLength = 0
         self.encoding = kwargs.pop('encoding', 'utf-8')
+        self.encodingErrors = kwargs.pop('encodingErrors', 'strict')
         # See if a shapefile name was passed as an argument
         if len(args) > 0:
             if is_string(args[0]):
@@ -635,7 +636,7 @@ class Reader:
                         value = None # unknown value is set to missing
             else:
                 # anything else is forced to string/unicode
-                value = u(value, self.encoding)
+                value = u(value, self.encoding, self.encodingErrors)
                 value = value.strip()
             record.append(value)
         return record

--- a/shapefile.py
+++ b/shapefile.py
@@ -559,9 +559,9 @@ class Reader:
             else:
                 idx = len(fieldDesc[name]) - 1
             fieldDesc[name] = fieldDesc[name][:idx]
-            fieldDesc[name] = u(fieldDesc[name], self.encoding)
+            fieldDesc[name] = u(fieldDesc[name], "ascii")
             fieldDesc[name] = fieldDesc[name].lstrip()
-            fieldDesc[1] = u(fieldDesc[1], self.encoding)
+            fieldDesc[1] = u(fieldDesc[1], "ascii")
             self.fields.append(fieldDesc)
         terminator = dbf.read(1)
         if terminator != b("\r"):

--- a/shapefile.py
+++ b/shapefile.py
@@ -79,13 +79,27 @@ if PYTHON3:
         return isinstance(v, str)
 
 else:
-    def b(v):
-        # For python 2 assume str passed in and return str.
-        return v
+    def b(v, encoding='utf-8', encodingErrors='strict'):
+        if isinstance(v, unicode):
+            # For python 2 encode unicode to bytes.
+            return v.encode(encoding, encodingErrors)
+        elif isinstance(v, bytes):
+            # Already bytes.
+            return v
+        else:
+            # Error.
+            raise Exception('Unknown input type')
 
-    def u(v, encoding='utf-8'):
-        # For python 2 assume str passed in and return str.
-        return v
+    def u(v, encoding='utf-8', encodingErrors='strict'):
+        if isinstance(v, bytes):
+            # For python 2 decode bytes to unicode.
+            return v.decode(encoding, encodingErrors)
+        elif isinstance(v, unicode):
+            # Already unicode.
+            return v
+        else:
+            # Error.
+            raise Exception('Unknown input type')
 
     def is_string(v):
         return isinstance(v, basestring)


### PR DESCRIPTION
In both Python 2 and 3, all records containing text values are now immediately decoded and returned as unicode based on the specified encoding. When writing, any unicode is encoded to the specified encoding. The encodingErrors option decides how to handle encoding errors. 

As per the shapefile specs, field names are encoded to ascii only. 