### PR TITLE
Fix Reader.__shape(self) for PointZ without M values

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -486,7 +486,7 @@ class Reader:
         if shapeType == 11:
             record.z = unpack("<d", f.read(8))
         # Read a single M value
-        if shapeType in (11,21):
+        if shapeType == 21 or (shapeType == 11 and f.tell() < next):
             record.m = unpack("<d", f.read(8))
         # Seek to the end of this record as defined by the record header because
         # the shapefile spec doesn't require the actual content to meet the header


### PR DESCRIPTION
M values are optional for the PointZ shape type. If a PointZ shapefile did not contain M values, the old code would incorrectly fetch bytes from the next record and store it in the `m` field. For the last record, the code would crash since `f.read(8)` would return an empty string.

In order to fix this, this commit checks whether there are any bytes left (`f.tell() < next1`) when the shape type is PointZ (`11`).