### PR TITLE
Add context manager to Reader and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+shapefile_[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9].dbf
+shapefile_[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9].shp
+shapefile_[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9].shx
+shapefiles/test/copy.dbf
+shapefiles/test/copy.shp
+shapefiles/test/copy.shx
+shapefiles/test/geojson.dbf
+shapefiles/test/geojson.shp
+shapefiles/test/geojson.shx
+shapefiles/test/latin_as_utf8.dbf
+shapefiles/test/latin_as_utf8.shp
+shapefiles/test/latin_as_utf8.shx
+shapefiles/test/null.dbf
+shapefiles/test/null.shp
+shapefiles/test/null.shx

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ objects are properly closed when done reading the data:
 
     >>> with shapefile.Reader("shapefiles/blockgroups.shp") as shp:
     ...     print(shp)
+    shapefile Reader
+        663 shapes (type 'POLYGON')
+        663 records (44 fields)
 
 ### Reading Shapefile Meta-Data
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The Python Shapefile Library (pyshp) reads and writes ESRI Shapefiles in pure Py
 [Examples](#examples)
 - [Reading Shapefiles](#reading-shapefiles)
   - [Reading Shapefiles from File-Like Objects](#reading-shapefiles-from-file-like-objects)
+  - [Reading Shapefile Using the Context Manager](#reading-shapefile-context-manager)
   - [Reading Shapefile Meta-Data](#reading-shapefile-meta-data)
   - [Reading Geometry](#reading-geometry)
   - [Reading Records](#reading-records)
@@ -117,6 +118,14 @@ very simple fixed-record index for the variable length records in the shp
 file. This file is optional for reading. If it's available pyshp will use the
 shx file to access shape records a little faster but will do just fine without
 it.
+
+### Reading Shapefile Using the Context Manager
+
+The "Reader" class can be used as a context manager, to ensure open file
+objects are properly closed when done reading the data:
+
+    >>> with shapefile.Reader("shapefiles/blockgroups.shp") as shp:
+    ...     print(shp)
 
 ### Reading Shapefile Meta-Data
 

--- a/shapefile.py
+++ b/shapefile.py
@@ -21,20 +21,29 @@ from datetime import date
 
 
 # Constants for shape types
-NULL = 0
-POINT = 1
-POLYLINE = 3
-POLYGON = 5
-MULTIPOINT = 8
-POINTZ = 11
-POLYLINEZ = 13
-POLYGONZ = 15
-MULTIPOINTZ = 18
-POINTM = 21
-POLYLINEM = 23
-POLYGONM = 25
-MULTIPOINTM = 28
-MULTIPATCH = 31
+SHAPE_TYPES = {
+    0: 'NULL',
+    1: 'POINT',
+    3: 'POLYLINE',
+    5: 'POLYGON',
+    8: 'MULTIPOINT',
+    11: 'POINTZ',
+    13: 'POLYLINEZ',
+    15: 'POLYGONZ',
+    18: 'MULTIPOINTZ',
+    21: 'POINTM',
+    23: 'POLYLINEM',
+    25: 'POLYGONM',
+    28: 'MULTIPOINTM',
+    31: 'MULTIPATCH'}
+# add inverse mapping and insert all into globals
+_thismodule = sys.modules[__name__]
+for num, name in SHAPE_TYPES.items():
+    setattr(_thismodule, name, num)
+    if name in SHAPE_TYPES:
+        # this is a conflict in shapetype names and should not happen
+        raise Exception()
+    SHAPE_TYPES[name] = num
 
 
 # Python 2-3 handling
@@ -349,6 +358,18 @@ class Reader(object):
             self.load()
         else:
             raise ShapefileException("Shapefile Reader requires a shapefile or file-like object.")
+
+    def __enter__(self):
+        """
+        Enter phase of context manager.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Exit phase of context manager, close opened files.
+        """
+        self.close()
 
     def __len__(self):
         """Returns the number of shapes/records in the shapefile."""

--- a/shapefile.py
+++ b/shapefile.py
@@ -384,15 +384,12 @@ class Reader(object):
         self.close()
 
     def close(self):
-        try:
-            if hasattr(self.shp, 'close'):
-                self.shp.close()
-            if hasattr(self.shx, 'close'):
-                self.shx.close()
-            if hasattr(self.dbf, 'close'):
-                self.dbf.close()
-        except IOError:
-            pass
+        for attribute in (self.shp, self.shx, self.dbf):
+            if hasattr(attribute, 'close'):
+                try:
+                    attribute.close()
+                except IOError:
+                    pass
 
     def __getFileObj(self, f):
         """Checks to see if the requested shapefile file object is

--- a/shapefile.py
+++ b/shapefile.py
@@ -359,6 +359,19 @@ class Reader(object):
         else:
             raise ShapefileException("Shapefile Reader requires a shapefile or file-like object.")
 
+    def __str__(self):
+        """
+        Use some general info on the shapefile as __str__
+        """
+        info = ['shapefile Reader']
+        if self.shp:
+            info.append("    {} shapes (type '{}')".format(
+                len(self.shapes()), SHAPE_TYPES[self.shapeType]))
+        if self.dbf:
+            info.append('    {} records ({} fields)'.format(
+                self.numRecords, len(self.fields)))
+        return '\n'.join(info)
+
     def __enter__(self):
         """
         Enter phase of context manager.

--- a/shapefile.py
+++ b/shapefile.py
@@ -38,7 +38,7 @@ SHAPE_TYPES = {
     31: 'MULTIPATCH'}
 # add inverse mapping and insert all into globals
 _thismodule = sys.modules[__name__]
-for num, name in SHAPE_TYPES.items():
+for num, name in list(SHAPE_TYPES.items()):
     setattr(_thismodule, name, num)
     if name in SHAPE_TYPES:
         # this is a conflict in shapetype names and should not happen

--- a/shapefile.py
+++ b/shapefile.py
@@ -185,7 +185,7 @@ def geojson_to_shape(geoj):
         shape.parts = parts
     return shape
 
-class Shape:
+class Shape(object):
     def __init__(self, shapeType=NULL, points=None, parts=None, partTypes=None):
         """Stores the geometry of the different shape types
         specified in the Shapefile spec. Shape types are
@@ -276,7 +276,7 @@ class Shape:
                     'coordinates': polys
                     }
 
-class ShapeRecord:
+class ShapeRecord(object):
     """A ShapeRecord object containing a shape along with its attributes."""
     def __init__(self, shape=None, record=None):
         self.shape = shape
@@ -286,7 +286,7 @@ class ShapefileException(Exception):
     """An exception to handle shapefile specific problems."""
     pass
 
-class Reader:
+class Reader(object):
     """Reads the three files of a shapefile as a unit or
     separately.  If one of the three files (.shp, .shx,
     .dbf) is missing no exception is thrown until you try
@@ -719,7 +719,7 @@ class Reader:
             yield ShapeRecord(shape=shape, record=record)
 
 
-class Writer:
+class Writer(object):
     """Provides write support for ESRI Shapefiles."""
     def __init__(self, shapeType=None, autoBalance=False, bufsize=None, **kwargs):
         self.autoBalance = autoBalance


### PR DESCRIPTION
Hi there, this PR proposes to add a context manager that makes sure open files are closed properly in the most Pythonic way there is (also see #107).

I've also made some other improvements (at least I think they are ;-), these can be singled out if you don't agree with all of them:
 - derive all classes from object (i.e. make them new style classes)
 - add convenience mapping "shapeType number" <---> "shapeType string" (keeping old module attributes like `shapefile.POINT`)
 - improve closing of individual pieces dbf/shp/shx, I think it's not safe right now, if one of these fails, the rest of them are not closed by `Reader.close()`

I've just started using `pyshp` for shapefile manipulations, thanks for the project! It's so convenient that it's noarch, pure Python and py2/3! ❤️ 

Eventually tests should really be implemented as unit tests, which is not a lot of work when relying on `pytest`, ~~and Travis~~ (ah Travis is set up already) and Appveyor should be set up as CI. I don't have time for this right now but might make a PR for this in the future..

Fixes #121 