### PR TITLE
Raise exceptions if too many fields are added

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -15,7 +15,6 @@ import sys
 import time
 import array
 import tempfile
-import itertools
 import io
 from datetime import date
 
@@ -876,6 +875,9 @@ class Writer:
         numRecs = self.recNum
         numFields = len(self.fields)
         headerLength = numFields * 32 + 33
+        if headerLength >= 65535:
+            raise ShapefileException(
+                    "Shapefile dbf header length exceeds maximum length.")
         recordLength = sum([int(field[2]) for field in self.fields]) + 1
         header = pack('<BBBBLHH20x', version, year, month, day, numRecs,
                 headerLength, recordLength)
@@ -1192,6 +1194,9 @@ class Writer:
         elif fieldType == "L":
             size = "1"
             decimal = 0
+        if len(self.fields) >= 2046:
+            raise ShapefileException(
+                "Shapefile Writer reached maximum number of fields: 2046.")
         self.fields.append((name, fieldType, size, decimal))
 
     def saveShp(self, target):


### PR DESCRIPTION
Fixes #140.

It seems that the maximum number of fields is 2046, as verified by checking `ogrinfo` outputs. Here is an example:
```python
import shapefile
w = shapefile.Writer()
n = 2046
for i in range(n):
    w.field("field{0}".format(i + 1), "N", 9, 0)
w.record(*range(n))
w.save('test')
```
if `n` is changed to anything higher than 2046, things break and ogrinfo cannot read the file. This PR raises an exception.