### PR TITLE
Fix date field less than 1900

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,14 +598,14 @@ Field length or decimal have no impact on this type:
 	>>> w.null()
 	>>> w.null()
 	>>> w.null()
-	>>> w.record(date(1998,1,30))
+	>>> w.record(date(1898,1,30))
 	>>> w.record([1998,1,30])
 	>>> w.record('19980130')
 	>>> w.record(None)
 	>>> w.save('shapefiles/test/dtype')
 	
 	>>> r = shapefile.Reader('shapefiles/test/dtype')
-	>>> assert r.record(0) == [date(1998,1,30)]
+	>>> assert r.record(0) == [date(1898,1,30)]
 	>>> assert r.record(1) == [date(1998,1,30)]
 	>>> assert r.record(2) == [date(1998,1,30)]
 	>>> assert r.record(3) == [None]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+VERSION 2.0.0-dev
+
+... Tobias Megies <megies@geophysik.uni-muenchen.de>
+	* Fixed bug writing shapefiles with datefield and date values earlier than 1900
+
 VERSION 1.2.11
 
 2017-04-29 Karim Bahgat <karim.bahgat.norway@gmail.com>

--- a/shapefile.py
+++ b/shapefile.py
@@ -1092,9 +1092,9 @@ class Writer:
             elif fieldType == "D":
                 # date: 8 bytes - date stored as a string in the format YYYYMMDD.
                 if isinstance(value, date):
-                    value = value.strftime("%Y%m%d")
+                    value = '{:04d}{:02d}{:02d}'.format(value.year, value.month, value.day)
                 elif isinstance(value, list) and len(value) == 3:
-                    value = date(*value).strftime("%Y%m%d")
+                    value = '{:04d}{:02d}{:02d}'.format(*value)
                 elif value in MISSING:
                     value = b'0' * 8 # QGIS NULL for date type
                 elif is_string(value) and len(value) == 8:


### PR DESCRIPTION
This fixes a bug when writing to date fields with values of before 1900AD. `datetime.datetime.strftime()` raises an exception when used with dates earlier than 1900AD but it's trivial to just use plain string formatting instead.