### PR TITLE
recordNr fix in Writer

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -914,9 +914,9 @@ class Writer:
     def __shpRecord(self, s):
         f = self.__getFileObj(self._shp)
         offset = 100 + f.tell()
+        self.shpNum += 1
         # Record number, Content length place holder
         f.write(pack(">2i", self.shpNum, 0))
-        self.shpNum += 1
         start = f.tell()
         # Shape Type
         if self.shapeType is None and s.shapeType != NULL:

--- a/shapefile.py
+++ b/shapefile.py
@@ -924,6 +924,10 @@ class Writer:
         if self.shapeType != 31 and s.shapeType != NULL and s.shapeType != self.shapeType:
             raise Exception("The shape's type (%s) must match the type of the shapefile (%s)." % (s.shapeType, self.shapeType))
         f.write(pack("<i", s.shapeType))
+
+        # For point just update bbox of the whole shapefile
+        if s.shapeType == 1:
+            self.__bbox(s)
         # All shape types capable of having a bounding box
         if s.shapeType in (3,5,8,13,15,18,23,25,28,31):
             try:


### PR DESCRIPTION
shapefile specs say that each record has its own recordNr value. And it should be 1-based. Currently it is written as 0-based. I added simple fix for that

Usually not a problem, but there are some libraries that check that and crash when incorrect.