### PR TITLE
README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ method.
     >>> len(list(sf.iterShapes()))
     663
 
-Each shape record contains the following attributes:
+Each shape record (except Points) contain the following attributes. Records of shapeType Point do not have a bounding box 'bbox'.
 
 
     >>> for name in dir(shapes[3]):


### PR DESCRIPTION
Edit docs to clarify that Points dont have a bounding box attribute 'bbox'.

Hello. Not sure if this is worth changing in the 1.2.x branch, but making the PR just in case.
I think it would be helpful to mention that Records of shapeType "Point" dont have a "bbox" attribute.

I am fairly new to the Geo world so it may be a given that Points dont have a bounding box? However I think it would be helpful to mention for beginners.