### PR TITLE
Fixed bugs when dealing with file-like objects

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -887,9 +887,9 @@ class Writer(object):
             shp,shx,dbf = kwargs.get('shp'), kwargs.get('shx'), kwargs.get('dbf')
             if shp:
                 self.shp = self.__getFileObj(shp)
-            elif shx:
+            if shx:
                 self.shx = self.__getFileObj(shx)
-            elif dbf:
+            if dbf:
                 self.dbf = self.__getFileObj(dbf)
         else:
             raise Exception('Either the target filepath, or any of shp, shx, or dbf must be set to create a shapefile.')

--- a/shapefile.py
+++ b/shapefile.py
@@ -875,6 +875,7 @@ class Reader(object):
 class Writer(object):
     """Provides write support for ESRI Shapefiles."""
     def __init__(self, target=None, shapeType=None, autoBalance=False, **kwargs):
+        self.target = target
         self.autoBalance = autoBalance
         self.fields = []
         self.shapeType = shapeType
@@ -956,13 +957,14 @@ class Writer(object):
         if self.dbf and dbf_open:
             self.__dbfHeader()
 
-        # Close files
-        for attribute in (self.shp, self.shx, self.dbf):
-            if hasattr(attribute, 'close'):
-                try:
-                    attribute.close()
-                except IOError:
-                    pass
+        # Close files, if target is a filepath
+        if self.target:
+            for attribute in (self.shp, self.shx, self.dbf):
+                if hasattr(attribute, 'close'):
+                    try:
+                        attribute.close()
+                    except IOError:
+                        pass
 
     def __getFileObj(self, f):
         """Safety handler to verify file-like objects"""


### PR DESCRIPTION
When attempting to write to a shapefile.Writer with BytesIO objects, just like the example, an exception is raised: `ShapefileException: No file-like object available.`. This was fixed by not ignoring the `shx` and `dbf` parameters after checking the `shp` parameter.

When exiting the context manager `with shapefile.Writer`, the BytesIO is closed and a `ValueError: I/O operation on closed file.` is raised when attempting to access the buffer later. I've changed the Writer.close method to only close the file object if the target is a filepath, similar to what the zipfile library does.

PS: This is my first PR ever, I apologise if I did something wrong!