### PR TITLE
Add contributors list to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,4 +1055,36 @@ $ python shapefile.py
 Linux/Mac and similar platforms will need to run `$ dos2unix README.md` in order
 correct line endings in README.md.
 
+# Contributors
 
+```
+Atle Frenvik Sveen
+Bas Couwenberg
+Casey Meisenzahl
+Charles Arnold
+David A. Riggs
+davidh-ssec
+Evan Heidtmann
+geospatialpython
+Hannes
+Ignacio Martinez Vazquez
+Jason Moujaes
+Karim Bahgat
+Kyle Kelley
+Louis Tiao
+Marcin Cuprjak
+Micah Cochran
+Michael Davis
+Michal Čihař
+Mike Toews
+Nilo
+Paulo Ernesto
+Raynor Vliegendhart
+Razzi Abuissa
+Ross Rogers
+Ryan Brideau
+Tobias Megies
+Tommi Penttinen
+Uli Köhler
+Zac Miller
+```


### PR DESCRIPTION
This is the list of contributors found by extracting the contributors
list from git logs up to this point in time.

The command used to extract this information was:
```
git log | grep Author | cut -d'<' -f1 | cut -d' ' -f2- | sort | uniq | sed 's/ $//'
```
Author names containing only email addresses as well as plain user name strings were removed. This pull request addresses the issue in #163 Is it ok like this? If you need an update or something differently please let me know and I will be happy to fix.