### PR TITLE
Fix exception thrown when writing empty records

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -1516,7 +1516,7 @@ class Writer(object):
         record = []
         fieldCount = len(self.fields)
         # Compensate for deletion flag
-        if self.fields[0][0].startswith("Deletion"): fieldCount -= 1
+        if self.fields and self.fields[0][0].startswith("Deletion"): fieldCount -= 1
         if recordList:
             record = [recordList[i] for i in range(fieldCount)]
         elif recordDict:
@@ -1542,7 +1542,7 @@ class Writer(object):
             self.__dbfHeader()
         # begin
         self.recNum += 1
-        if not self.fields[0][0].startswith("Deletion"):
+        if self.fields and not self.fields[0][0].startswith("Deletion"):
             f.write(b' ') # deletion flag
         for (fieldName, fieldType, size, deci), value in zip(self.fields, record):
             fieldType = fieldType.upper()


### PR DESCRIPTION
e.g.

    Traceback (most recent call last):
    File "filter_shp.py", line 12, in <module>
        w.record(*shaperec.record)
    File "shapefile.py", line 1663, in record
        self.__dbfRecord(record)
    File "shapefile.py", line 1675, in __dbfRecord
        if not self.fields[0][0].startswith("Deletion"):
    IndexError: list index out of range
    Exception ignored in: <function Writer.__del__ at 0x107810730>
    Traceback (most recent call last):
    File "shapefile.py", line 1157, in __del__
    File "shapefile.py", line 1176, in close
    shapefile.ShapefileException: When saving both the dbf and shp file, the number of records (1) must correspond with the number of shapes (0)