### PR TITLE
Fixed fields in the reader geo interface

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -617,7 +617,7 @@ class Reader(object):
 
     @property
     def __geo_interface__(self):
-        fieldnames = [f[0] for f in self.fields]
+        fieldnames = [f[0] for f in self.fields if f[0] != 'DeletionFlag']
         features = []
         for feat in self.iterShapeRecords():
             fdict = {'type': 'Feature',


### PR DESCRIPTION
Fix for the following error:
```python
In [1]: import shapefile                                                                                                                                                                                                                     
In [2]: r = shapefile.Reader('shapefiles/blockgroups')                                                                                                                                                                                       
In [3]: r.record(0).as_dict() == r.__geo_interface__['features'][0]['properties']                                                                                                                                                            
Out[3]: False
```