### PR TITLE
Issue #215: Fix for record number with iterRecords

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -1316,7 +1316,7 @@ class Reader(object):
         f = self.__getFileObj(self.dbf)
         f.seek(self.__dbfHdrLength)
         for i in xrange(self.numRecords):
-            r = self.__record()
+            r = self.__record(oid=i)
             if r:
                 yield r
 


### PR DESCRIPTION
This is a fix for record numbers ("Record #-1") showing -1 with iterRecords. Refer to Issue #215 