### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Users of the previous version 1.x should therefore take note of the following ch
 - Reading shapefiles is now more convenient:
   - Shapefiles can be opened using the context manager, and files are properly closed. 
   - Shapefiles can be iterated, have a length, and supports the geo interface. 
-  - New ways of inspecing shapefile metadata by printing. [@megies]
+  - New ways of inspecting shapefile metadata by printing. [@megies]
   - More convenient accessing of Record values as attributes. [@philippkraft]
   - More convenient shape type name checking. [@megies] 
 - Add more support and documentation for MultiPatch 3D shapes. 
@@ -390,7 +390,7 @@ where lines and polygons are grouped for you:
 	>>> geoj["type"]
 	'MultiPolygon'
 	
-The results from the shapes() method similiarly supports converting to GeoJSON:
+The results from the shapes() method similarly supports converting to GeoJSON:
 
 
 	>>> shapes.__geo_interface__['type']

--- a/shapefile.py
+++ b/shapefile.py
@@ -151,7 +151,7 @@ else:
 # Begin
 
 class _Array(array.array):
-    """Converts python tuples to lists of the appropritate type.
+    """Converts python tuples to lists of the appropriate type.
     Used to unpack different shapefile header parts."""
     def __repr__(self):
         return str(self.tolist())
@@ -1488,7 +1488,7 @@ class Writer(object):
                 z.append(p[2])
             except IndexError:
                 # point did not have z value
-                # setting it to 0 is probably ok, since it means all are on the same elavation
+                # setting it to 0 is probably ok, since it means all are on the same elevation
                 z.append(0)
         zbox = [min(z), max(z)]
         # update global
@@ -2026,7 +2026,7 @@ class Writer(object):
         PartTypes is a list of types that define each of the surface patches.
         The types can be any of the following module constants: TRIANGLE_STRIP,
         TRIANGLE_FAN, OUTER_RING, INNER_RING, FIRST_RING, or RING.
-        If the z (elavation) value is not included, it defaults to 0.
+        If the z (elevation) value is not included, it defaults to 0.
         If the m (measure) value is not included, it defaults to None (NoData)."""
         shapeType = MULTIPATCH
         polyShape = Shape(shapeType)


### PR DESCRIPTION
There are small typos in:
- README.md
- shapefile.py

Fixes:
- Should read `similarly` rather than `similiarly`.
- Should read `appropriate` rather than `appropritate`.
- Should read `elevation` rather than `elavation`.
- Should read `inspecting` rather than `inspecing`.

Closes #218