### PR TITLE
Mark tests requiring network.

### DIFF
--- a/test_shapefile.py
+++ b/test_shapefile.py
@@ -260,6 +260,7 @@ def test_reader_context_manager():
     assert sf.shx.closed is True
 
 
+@pytest.mark.network
 def test_reader_url():
     """
     Assert that Reader can open shapefiles from a url.


### PR DESCRIPTION
The Debian package build for pyshp failed because there is no network in the build environment.

The tests that download data need to be skipped, for this the `network` marker was added to `test_reader_url()`.