### PR TITLE
Register pytest mark “network”

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    network: marks tests requiring network access


### PR DESCRIPTION
Prevents `PytestUnknownMarkWarning` when using the mark to deselect tests.

See also https://docs.pytest.org/en/stable/mark.html, and #230, in which the mark was (very helpfully) introduced.