### PR TITLE
Convert setup.py to declarative configuration setup.cfg file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      run: python -m build --sdist --wheel --outdir dist/
+      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = pyshp
+version = attr: shapefile.__version__
+description = Pure Python read/write support for ESRI Shapefile format
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Joel Lawhead
+author_email = jlawhead@geospatialpython.com
+maintainer = Karim Bahgat
+maintainer_email = karim.bahgat.norway@gmail.com
+url = https://github.com/GeospatialPython/pyshp
+download_url = https://pypi.org/project/pyshp/
+license = MIT
+license_files = LICENSE.TXT
+keywords = gis, geospatial, geographic, shapefile, shapefiles
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: GIS
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+py_modules = shapefile
+python_requires = >=2.7
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,3 @@
 from setuptools import setup
 
-
-def read_file(file):
-    with open(file, 'rb') as fh:
-        data = fh.read()
-    return data.decode('utf-8')
-
-setup(name='pyshp',
-      version='2.2.0',
-      description='Pure Python read/write support for ESRI Shapefile format',
-      long_description=read_file('README.md'),
-      long_description_content_type='text/markdown',
-      author='Joel Lawhead, Karim Bahgat',
-      author_email='jlawhead@geospatialpython.com',
-      url='https://github.com/GeospatialPython/pyshp',
-      py_modules=['shapefile'],
-      license='MIT',
-      zip_safe=False,
-      keywords='gis geospatial geographic shapefile shapefiles',
-      python_requires='>= 2.7',
-      classifiers=['Programming Language :: Python',
-                   'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.5',
-                   'Programming Language :: Python :: 3.6',
-                   'Programming Language :: Python :: 3.7',
-                   'Programming Language :: Python :: 3.8',
-                   'Programming Language :: Python :: 3.9',
-                   'Topic :: Scientific/Engineering :: GIS',
-                   'Topic :: Software Development :: Libraries',
-                   'Topic :: Software Development :: Libraries :: Python Modules'])
+setup()


### PR DESCRIPTION
Refer to [setuptools' declarative configuration page](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) for moving the static metadata into `setup.cfg`.

A few other notes:
- Use `pyproject.toml` for [PEP 517](https://www.python.org/dev/peps/pep-0517/) implementation, but keep setuptools as build backend for now
- A universal wheel is now built for both Python 2 and 3 compatibility (using `[bdist_wheel] universal=1`; when py2 is eventually dropped, then remove that section)
- Version is dynamically read from `shapefile.py`
- Remove the various Python 3.x classifiers, and just use Python 3, as this is an unnecessary maintenance classifier as old packages should work fine with future Python versions (Python 2.7 is the sole exception); add a few other classifiers
- Setuptools' author field is really designed to only hold one; move @karimbahgat as maintainer (same as README.md)
- [`zip_safe`](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#setting-the-zip-safe-flag) was removed as it's not needed
- Now `setup.py` is a simple wrapper, which some folks expect to see; it may go away someday