### PR TITLE
Enhancements to `__geo_interface__`

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -336,7 +336,11 @@ def ring_contains_ring(coords1, coords2):
 
 def organize_polygonz_rings(rings, return_errors=None):
     #FIXME: so far, we treat everything as an outer ring
-    return rings
+    polygons = []
+    for ring in rings:
+        polygon = [ring]
+        polygons.append(polygon)
+    return polygons
 
 
 def organize_polygon_rings(rings, return_errors=None):

--- a/shapefile.py
+++ b/shapefile.py
@@ -510,7 +510,7 @@ class Shape(object):
 
     @property
     def __geo_interface__(self):
-        points =self._points_z
+        points = self._points_z
         if self.shapeType in [POINT, POINTM, POINTZ]:
             # point
             if len(points) == 0:

--- a/shapefile.py
+++ b/shapefile.py
@@ -595,7 +595,6 @@ class Shape(object):
 
                 # organize rings into list of polygons, where each polygon is defined as list of rings.
                 # the first ring is the exterior and any remaining rings are holes (same as GeoJSON). 
-                print(rings)
                 polys = organize_polygon_rings(rings, self._errors)
                 self._post_error_msg_print()
                 # return as geojson
@@ -632,7 +631,6 @@ class Shape(object):
 
                 # organize rings into list of polygons, where each polygon is defined as list of rings.
                 # the first ring is the exterior and any remaining rings are holes (same as GeoJSON). 
-                print(rings)
                 polys = organize_polygonz_rings(rings, self._errors)
                 self._post_error_msg_print()
                 # return as geojson


### PR DESCRIPTION
Hello, I have made a few small enhancements to `__geo_interface__`:
- I have added support for `MULTIPATCH` based on the [original ESRI white paper](https://www.esri.com/content/dam/esrisites/sitecore-archive/Files/Pdfs/library/whitepapers/pdfs/shapefile.pdf) and its [2008 extension](https://www.esri.com/library/whitepapers/pdfs/multipatch-geometry-type.pdfData)
- if the `Shape` object has a `z` attribute, the coordinates of the `__geo_interface__` will also contain the z-values

As of now, there are no tests for the `MULTIPATCH`. I would love to add them, but I could find SHP files containing only `MULTIPATCH` type 2 (Outer ring).  