### PR TITLE
Add spatial filtering for single points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,7 +1224,7 @@ Selectively reading only the necessary data in this way is particularly useful f
 
 ### Spatial filtering
 
-Another common use-case is that we only want to read those records that are located in some region of interest. Because the shapefile stores the bounding box of each shape separately from the geometry data, it's possible to quickly retrieve all shapes that might overlap a given bounding box region without having to load the full shape geometry data for every shape. This can be done by specifying the `bbox` argument to any of the record or shape methods:
+Another common use-case is that we only want to read those records that are located in some region of interest. Because the shapefile stores the bounding box of each shape separately from the geometry data, it's possible to quickly retrieve all shapes that might overlap a given bounding box region without having to load the full shape geometry data for every shape. This can be done by specifying the `bbox` argument to the shapes, iterShapes, or iterShapeRecords methods:
 
 
 	>>> bbox = [36.423, 12.360, 43.123, 18.004] # ca bbox of Eritrea

--- a/shapefile.py
+++ b/shapefile.py
@@ -1360,6 +1360,12 @@ class Reader(object):
         # Read a single point
         if shapeType in (1,11,21):
             record.points = [_Array('d', unpack("<2d", f.read(16)))]
+            # create bounding box for Point by duplicating coordinates
+            point_bbox = list(record.points[0] + record.points[0])
+            # skip shape if no overlap with bounding box
+            if not bbox_overlap(bbox, point_bbox):
+                f.seek(next)
+                return None
         # Read a single Z value
         if shapeType == 11:
             record.z = list(unpack("<d", f.read(8)))

--- a/shapefile.py
+++ b/shapefile.py
@@ -1360,12 +1360,13 @@ class Reader(object):
         # Read a single point
         if shapeType in (1,11,21):
             record.points = [_Array('d', unpack("<2d", f.read(16)))]
-            # create bounding box for Point by duplicating coordinates
-            point_bbox = list(record.points[0] + record.points[0])
-            # skip shape if no overlap with bounding box
-            if not bbox_overlap(bbox, point_bbox):
-                f.seek(next)
-                return None
+            if bbox is not None:
+                # create bounding box for Point by duplicating coordinates
+                point_bbox = list(record.points[0] + record.points[0])
+                # skip shape if no overlap with bounding box
+                if not bbox_overlap(bbox, point_bbox):
+                    f.seek(next)
+                    return None
         # Read a single Z value
         if shapeType == 11:
             record.z = list(unpack("<d", f.read(8)))


### PR DESCRIPTION
Investigating #258, I confirmed that single points where not being filtered using the bbox parameter. This is added here by duplicating the coordinates of the point to allow for comparison against bbox. A statement from the manual is also updated (since records and iterRecords methods do not allow spatial filtering).