### PR TITLE
Fix PyShp's CI, dropping actions/setup-python, running build.yml Action in Python Docker containers. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7.18", , "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+        python-version: ["2.7.18", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7.18", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.python-version }}-slim
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ PyShp-fix-CI ]
   pull_request:
-    branches: [ master ]
+    branches: [ PyShp-fix-CI ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7.18", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+        python-version: ["2.7.18", , "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ PyShp-fix-CI ]
+    branches: [ master ]
   pull_request:
-    branches: [ PyShp-fix-CI ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 dist/
 *.egg-info/
 *.py[cod]
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "https://json.schemastore.org/github-workflow.json": "file:///c%3A/Users/drjam/Coding/repos/IronPyShp/.github/workflows/deploy.yml"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "yaml.schemas": {
-        "https://json.schemastore.org/github-workflow.json": "file:///c%3A/Users/drjam/Coding/repos/IronPyShp/.github/workflows/deploy.yml"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -1082,13 +1082,15 @@ A .prj file, or projection file, is a simple text file that stores a shapefile's
 
 If you're using the same projection over and over, the following is a simple way to create the .prj file assuming your base filename is stored in a variable called "filename":
 
-	>>> with open("{}.prj".format(filename), "w") as prj:
-	>>>     wkt = 'GEOGCS["WGS 84",'
-	>>>     wkt += 'DATUM["WGS_1984",'
-	>>>     wkt += 'SPHEROID["WGS 84",6378137,298.257223563]]'
-	>>>     wkt += ',PRIMEM["Greenwich",0],'
-	>>>     wkt += 'UNIT["degree",0.0174532925199433]]'
-	>>>     prj.write(wkt)
+```
+	with open("{}.prj".format(filename), "w") as prj:
+	    wkt = 'GEOGCS["WGS 84",'
+	    wkt += 'DATUM["WGS_1984",'
+	    wkt += 'SPHEROID["WGS 84",6378137,298.257223563]]'
+	    wkt += ',PRIMEM["Greenwich",0],'
+	    wkt += 'UNIT["degree",0.0174532925199433]]'
+	    prj.write(wkt)
+```
 
 If you need to dynamically fetch WKT projection strings, you can use the pure Python [PyCRS](https://github.com/karimbahgat/PyCRS) module which has a number of useful features. 
 

--- a/README.md
+++ b/README.md
@@ -1097,7 +1097,7 @@ If you need to dynamically fetch WKT projection strings, you can use the pure Py
 # Advanced Use
 
 ## Common Errors and Fixes
-
+ 
 Below we list some commonly encountered errors and ways to fix them. 
 
 ### Warnings and Logging

--- a/README.md
+++ b/README.md
@@ -1097,7 +1097,7 @@ If you need to dynamically fetch WKT projection strings, you can use the pure Py
 # Advanced Use
 
 ## Common Errors and Fixes
- 
+
 Below we list some commonly encountered errors and ways to fix them. 
 
 ### Warnings and Logging


### PR DESCRIPTION
This is trickier to test than normal, as as far as I can tell Github actions are only run from the master branch (and I've renamed master to main in my fork).  There might be some other bug or subtlety I've missed, but in my fork's main branch I've got the same build.yml file, only targetting the branch from which this PR is coming (in which build.yml targets master).  

This PR is from a branch based on the branch from which I raised my previous PR, #265 so it includes the blocking out of the failing Doctest.  the test results for PyShp are all green on Pythons 2.7, 3.5, ..., 3.9.
![image](https://github.com/GeospatialPython/pyshp/assets/80779630/bdde29a9-4d86-44ba-bbea-60180ef5e854)
https://github.com/JamesParrott/IronPyShp/actions/runs/7545262680/job/20540473529

Summary of changes:
 - Drop actions/setup-python, move the matrix strategy forward, pin to the specific patch versions below, and use the matrix to run the action in Python Slim containers (versions 2.7.18, 3.5.10, 3.6.15, 3.7.17, 3.8.18, and 3.9.18)
 - Bump actions/checkout from v2 to v3
 - Reformat PyShp usage example with undefined variable in readme.md from >>> to Markdown code literal block, so doctest skips it, as for PR # 265.
 - Don't track my VS Code settings files.