### PR TITLE
Test Pyshp in CI in Python 3.10, 3.11, 3.12 and 3.13 containers.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ PyShp-CI-test-on-Python-3.10+ ]
+    branches: [ "PyShp-CI-test-on-Python-3.10+" ]
   pull_request:
-    branches: [ PyShp-CI-test-on-Python-3.10+ ]
+    branches: [ "PyShp-CI-test-on-Python-3.10+" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ "PyShp-CI-test-on-Python-3.10+" ]
+    branches: [ "PyShp-test-on-Pythons-3.10-3.13" ]
   pull_request:
-    branches: [ "PyShp-CI-test-on-Python-3.10+" ]
+    branches: [ "PyShp-test-on-Pythons-3.10-3.13" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7.18", , "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+        python-version: ["2.7.18", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7.18", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.python-version }}-slim
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ PyShp-fix-CI ]
   pull_request:
-    branches: [ master ]
+    branches: [ PyShp-fix-CI ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ PyShp-CI-test-on-Python-3.10+ ]
   pull_request:
-    branches: [ master ]
+    branches: [ PyShp-CI-test-on-Python-3.10+ ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7.18", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+        python-version: ["2.7.18", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18",  "3.10.13", "3.11.7", "3.12.1", "3.13.0a2"]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ "PyShp-test-on-Pythons-3.10-3.13" ]
+    branches: [ master ]
   pull_request:
-    branches: [ "PyShp-test-on-Pythons-3.10-3.13" ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7.18", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
+        python-version: ["2.7.18", , "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18"]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ PyShp-fix-CI ]
+    branches: [ master ]
   pull_request:
-    branches: [ PyShp-fix-CI ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 dist/
 *.egg-info/
 *.py[cod]
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "https://json.schemastore.org/github-workflow.json": "file:///c%3A/Users/drjam/Coding/repos/IronPyShp/.github/workflows/deploy.yml"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "yaml.schemas": {
-        "https://json.schemastore.org/github-workflow.json": "file:///c%3A/Users/drjam/Coding/repos/IronPyShp/.github/workflows/deploy.yml"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -1082,13 +1082,15 @@ A .prj file, or projection file, is a simple text file that stores a shapefile's
 
 If you're using the same projection over and over, the following is a simple way to create the .prj file assuming your base filename is stored in a variable called "filename":
 
-	>>> with open("{}.prj".format(filename), "w") as prj:
-	>>>     wkt = 'GEOGCS["WGS 84",'
-	>>>     wkt += 'DATUM["WGS_1984",'
-	>>>     wkt += 'SPHEROID["WGS 84",6378137,298.257223563]]'
-	>>>     wkt += ',PRIMEM["Greenwich",0],'
-	>>>     wkt += 'UNIT["degree",0.0174532925199433]]'
-	>>>     prj.write(wkt)
+```
+	with open("{}.prj".format(filename), "w") as prj:
+	    wkt = 'GEOGCS["WGS 84",'
+	    wkt += 'DATUM["WGS_1984",'
+	    wkt += 'SPHEROID["WGS 84",6378137,298.257223563]]'
+	    wkt += ',PRIMEM["Greenwich",0],'
+	    wkt += 'UNIT["degree",0.0174532925199433]]'
+	    prj.write(wkt)
+```
 
 If you need to dynamically fetch WKT projection strings, you can use the pure Python [PyCRS](https://github.com/karimbahgat/PyCRS) module which has a number of useful features. 
 

--- a/README.md
+++ b/README.md
@@ -1097,7 +1097,7 @@ If you need to dynamically fetch WKT projection strings, you can use the pure Py
 # Advanced Use
 
 ## Common Errors and Fixes
-
+ 
 Below we list some commonly encountered errors and ways to fix them. 
 
 ### Warnings and Logging

--- a/README.md
+++ b/README.md
@@ -1097,7 +1097,7 @@ If you need to dynamically fetch WKT projection strings, you can use the pure Py
 # Advanced Use
 
 ## Common Errors and Fixes
- 
+
 Below we list some commonly encountered errors and ways to fix them. 
 
 ### Warnings and Logging

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,2 +1,2 @@
-pytest==3.2.5
+pytest==3.2.5 
 setuptools

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,2 +1,2 @@
-pytest==3.2.5 
+pytest
 setuptools


### PR DESCRIPTION
Implements issue #268.  Incorporates PR #267 and PR #265

Summary of changes:
 - Unpin Pytest version.
 - Add Python slim Docker containers for tags 3.10.13, 3.11.7, 3.12.1, and 3.13.0a2 to the test matrix.  
As for PR #267:
 - Drop actions/setup-python, move the matrix strategy forward, pin to the specific patch versions below, and use the matrix to run the action in Python Slim containers (versions 2.7.18, 3.5.10, 3.6.15, 3.7.17, 3.8.18, and 3.9.18)
 -  Bump actions/checkout from v2 to v3
 -  Don't track my VS Code settings files.
As for PR #265
 -   Reformat PyShp usage example with undefined variable in readme.md from >>> to Markdown code literal block, so doctest skips it, as for PR # 265.
