### PR TITLE
cleanup: codespell and remove trailing empty spaces.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     id: pyshp-version
     attributes:
       label: PyShp Version
-      description: Please input the version of PyShp you used. If unsure, call `shapefile.__version__`. 
+      description: Please input the version of PyShp you used. If unsure, call `shapefile.__version__`.
       placeholder: ...
     validations:
       required: true
@@ -15,7 +15,7 @@ body:
     id: python-version
     attributes:
       label: Python Version
-      description: Please input the version of the Python executable. 
+      description: Please input the version of the Python executable.
       placeholder: ...
     validations:
       required: true
@@ -23,7 +23,7 @@ body:
     id: your-code
     attributes:
       label: Your code
-      description: Please copy-paste the relevant parts of your code or script that triggered the error. 
+      description: Please copy-paste the relevant parts of your code or script that triggered the error.
       placeholder: ...
       render: shell
     validations:
@@ -41,7 +41,7 @@ body:
     id: notes
     attributes:
       label: Other notes
-      description: Please input any other notes that may be relevant, e.g. do you have any thoughts on what might be wrong? 
+      description: Please input any other notes that may be relevant, e.g. do you have any thoughts on what might be wrong?
       placeholder: ...
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/newfeature.yml
+++ b/.github/ISSUE_TEMPLATE/newfeature.yml
@@ -15,7 +15,7 @@ body:
     id: contribute
     attributes:
       label: Contributions
-      description: Would you be interested to contribute code that adds this functionality through a Pull Request? We gladly accept PRs - it's much faster and you'll be added a contributor. 
+      description: Would you be interested to contribute code that adds this functionality through a Pull Request? We gladly accept PRs - it's much faster and you'll be added a contributor.
       options:
         - label: I am interested in implementing the described feature request and submit as a PR.
           required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,7 +6,7 @@ body:
   - type: textarea
     id: question
     attributes:
-      label: What's your question? 
+      label: What's your question?
       description: Please describe what you would like to know about PyShp, e.g. how to do something.
       placeholder: ...
     validations:

--- a/.github/ISSUE_TEMPLATE/unexpected.yml
+++ b/.github/ISSUE_TEMPLATE/unexpected.yml
@@ -7,7 +7,7 @@ body:
     id: pyshp-version
     attributes:
       label: PyShp Version
-      description: Please input the version of PyShp you used. If unsure, call `shapefile.__version__`. 
+      description: Please input the version of PyShp you used. If unsure, call `shapefile.__version__`.
       placeholder: ...
     validations:
       required: true
@@ -15,7 +15,7 @@ body:
     id: python-version
     attributes:
       label: Python Version
-      description: Please input the version of the Python executable. 
+      description: Please input the version of the Python executable.
       placeholder: ...
     validations:
       required: true
@@ -23,7 +23,7 @@ body:
     id: your-code
     attributes:
       label: Your code
-      description: Please copy-paste the relevant parts of your code or script that you tried to run. 
+      description: Please copy-paste the relevant parts of your code or script that you tried to run.
       placeholder: ...
       render: shell
     validations:
@@ -48,7 +48,7 @@ body:
     id: notes
     attributes:
       label: Other notes
-      description: Please input any other notes that may be relevant, e.g. do you have any thoughts on what might be wrong? 
+      description: Please input any other notes that may be relevant, e.g. do you have any thoughts on what might be wrong?
       placeholder: ...
     validations:
       required: false

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,5 +1,5 @@
 The MIT License (MIT)
- 
+
 Copyright © 2013 Joel Lawhead
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ despite the numerous ways to store and exchange GIS data available today.
 
 Pyshp is compatible with Python 2.7-3.x.
 
-This document provides examples for using PyShp to read and write shapefiles. However 
+This document provides examples for using PyShp to read and write shapefiles. However
 many more examples are continually added to the blog [http://GeospatialPython.com](http://GeospatialPython.com),
-and by searching for PyShp on [https://gis.stackexchange.com](https://gis.stackexchange.com). 
+and by searching for PyShp on [https://gis.stackexchange.com](https://gis.stackexchange.com).
 
 Currently the sample census blockgroup shapefile referenced in the examples is available on the GitHub project site at
 [https://github.com/GeospatialPython/pyshp](https://github.com/GeospatialPython/pyshp). These
 examples are straight-forward and you can also easily run them against your
-own shapefiles with minimal modification. 
+own shapefiles with minimal modification.
 
 Important: If you are new to GIS you should read about map projections.
 Please visit: [https://github.com/GeospatialPython/pyshp/wiki/Map-Projections](https://github.com/GeospatialPython/pyshp/wiki/Map-Projections)
@@ -105,7 +105,7 @@ part of your geospatial project.
 
 ### New Features:
 
-- Added support for pathlib and path-like shapefile filepaths (@mwtoews). 
+- Added support for pathlib and path-like shapefile filepaths (@mwtoews).
 - Allow reading individual file extensions via filepaths.
 
 ### Improvements:
@@ -119,7 +119,7 @@ part of your geospatial project.
 - More robust handling of corrupt shapefiles (fixes #235)
 - Fix errors when writing to individual file-handles (fixes #237)
 - Revert previous decision to enforce geojson output ring orientation (detailed explanation at https://github.com/SciTools/cartopy/issues/2012)
-- Fix test issues in environments without network access (@sebastic, @musicinmybrain). 
+- Fix test issues in environments without network access (@sebastic, @musicinmybrain).
 
 ## 2.2.0
 
@@ -132,7 +132,7 @@ part of your geospatial project.
 
 ### Improvements:
 
-- More examples and restructuring of README. 
+- More examples and restructuring of README.
 - More informative Shape to geojson warnings (see #219).
 - Add shapefile.VERBOSE flag to control warnings verbosity (default True).
 - Shape object information when calling repr().
@@ -189,7 +189,7 @@ part of your geospatial project.
 
 ### New Features:
 
-- Added back read/write support for unicode field names. 
+- Added back read/write support for unicode field names.
 - Improved Record representation
 - More support for geojson on Reader, ShapeRecord, ShapeRecords, and shapes()
 
@@ -201,38 +201,38 @@ part of your geospatial project.
 
 ## 2.0.0
 
-The newest version of PyShp, version 2.0 introduced some major new improvements. 
+The newest version of PyShp, version 2.0 introduced some major new improvements.
 A great thanks to all who have contributed code and raised issues, and for everyone's
-patience and understanding during the transition period. 
-Some of the new changes are incompatible with previous versions. 
+patience and understanding during the transition period.
+Some of the new changes are incompatible with previous versions.
 Users of the previous version 1.x should therefore take note of the following changes
-(Note: Some contributor attributions may be missing): 
+(Note: Some contributor attributions may be missing):
 
 ### Major Changes:
 
-- Full support for unicode text, with custom encoding, and exception handling. 
-  - Means that the Reader returns unicode, and the Writer accepts unicode. 
-- PyShp has been simplified to a pure input-output library using the Reader and Writer classes, dropping the Editor class. 
+- Full support for unicode text, with custom encoding, and exception handling.
+  - Means that the Reader returns unicode, and the Writer accepts unicode.
+- PyShp has been simplified to a pure input-output library using the Reader and Writer classes, dropping the Editor class.
 - Switched to a new streaming approach when writing files, keeping memory-usage at a minimum:
-  - Specify filepath/destination and text encoding when creating the Writer. 
-  - The file is written incrementally with each call to shape/record. 
-  - Adding shapes is now done using dedicated methods for each shapetype. 
+  - Specify filepath/destination and text encoding when creating the Writer.
+  - The file is written incrementally with each call to shape/record.
+  - Adding shapes is now done using dedicated methods for each shapetype.
 - Reading shapefiles is now more convenient:
-  - Shapefiles can be opened using the context manager, and files are properly closed. 
-  - Shapefiles can be iterated, have a length, and supports the geo interface. 
+  - Shapefiles can be opened using the context manager, and files are properly closed.
+  - Shapefiles can be iterated, have a length, and supports the geo interface.
   - New ways of inspecting shapefile metadata by printing. [@megies]
   - More convenient accessing of Record values as attributes. [@philippkraft]
-  - More convenient shape type name checking. [@megies] 
-- Add more support and documentation for MultiPatch 3D shapes. 
-- The Reader "elevation" and "measure" attributes now renamed "zbox" and "mbox", to make it clear they refer to the min/max values. 
-- Better documentation of previously unclear aspects, such as field types. 
+  - More convenient shape type name checking. [@megies]
+- Add more support and documentation for MultiPatch 3D shapes.
+- The Reader "elevation" and "measure" attributes now renamed "zbox" and "mbox", to make it clear they refer to the min/max values.
+- Better documentation of previously unclear aspects, such as field types.
 
 ### Important Fixes:
 
 - More reliable/robust:
   - Fixed shapefile bbox error for empty or point type shapefiles. [@mcuprjak]
   - Reading and writing Z and M type shapes is now more robust, fixing many errors, and has been added to the documentation. [@ShinNoNoir]
-  - Improved parsing of field value types, fixed errors and made more flexible. 
+  - Improved parsing of field value types, fixed errors and made more flexible.
   - Fixed bug when writing shapefiles with datefield and date values earlier than 1900 [@megies]
 - Fix some geo interface errors, including checking polygon directions.
 - Bug fixes for reading from case sensitive file names, individual files separately, and from file-like objects. [@gastoneb, @kb003308, @erickskb]
@@ -275,7 +275,7 @@ OR
 	>>> sf = shapefile.Reader("shapefiles/blockgroups.dbf")
 
 OR any of the other 5+ formats which are potentially part of a shapefile. The
-library does not care about file extensions. You can also specify that you only 
+library does not care about file extensions. You can also specify that you only
 want to read some of the file extensions through the use of keyword arguments:
 
 
@@ -283,7 +283,7 @@ want to read some of the file extensions through the use of keyword arguments:
 
 #### Reading Shapefiles from Zip Files
 
-If your shapefile is wrapped inside a zip file, the library is able to handle that too, meaning you don't have to worry about unzipping the contents: 
+If your shapefile is wrapped inside a zip file, the library is able to handle that too, meaning you don't have to worry about unzipping the contents:
 
 
 	>>> sf = shapefile.Reader("shapefiles/blockgroups.zip")
@@ -295,7 +295,7 @@ If the zip file contains multiple shapefiles, just specify which shapefile to re
 
 #### Reading Shapefiles from URLs
 
-Finally, you can use all of the above methods to read shapefiles directly from the internet, by giving a url instead of a local path, e.g.: 
+Finally, you can use all of the above methods to read shapefiles directly from the internet, by giving a url instead of a local path, e.g.:
 
 
 	>>> # from a zipped shapefile on website
@@ -337,8 +337,8 @@ objects are properly closed when done reading the data:
 #### Reading Shapefile Meta-Data
 
 Shapefiles have a number of attributes for inspecting the file contents.
-A shapefile is a container for a specific type of geometry, and this can be checked using the 
-shapeType attribute. 
+A shapefile is a container for a specific type of geometry, and this can be checked using the
+shapeType attribute.
 
 
 	>>> sf = shapefile.Reader("shapefiles/blockgroups.dbf")
@@ -364,7 +364,7 @@ the existing shape types are not sequential:
 - POLYGONM = 25
 - MULTIPOINTM = 28
 - MULTIPATCH = 31
-	
+
 Based on this we can see that our blockgroups shapefile contains
 Polygon type shapes. The shape types are also defined as constants in
 the shapefile module, so that we can compare types more intuitively:
@@ -378,8 +378,8 @@ For convenience, you can also get the name of the shape type as a string:
 
 	>>> sf.shapeTypeName == 'POLYGON'
 	True
-	
-Other pieces of meta-data that we can check include the number of features 
+
+Other pieces of meta-data that we can check include the number of features
 and the bounding box area the shapefile covers:
 
 
@@ -387,10 +387,10 @@ and the bounding box area the shapefile covers:
 	663
 	>>> sf.bbox
 	[-122.515048, 37.652916, -122.327622, 37.863433]
-	
+
 Finally, if you would prefer to work with the entire shapefile in a different
 format, you can convert all of it to a GeoJSON dictionary, although you may lose
-some information in the process, such as z- and m-values: 
+some information in the process, such as z- and m-values:
 
 
 	>>> sf.__geo_interface__['type']
@@ -415,7 +415,7 @@ each shape record.
 
 	>>> len(shapes)
 	663
-	
+
 To read a single shape by calling its index use the shape() method. The index
 is the shape's count from 0. So to read the 8th shape record you would use its
 index which is 7.
@@ -457,12 +457,12 @@ shapeType Point do not have a bounding box 'bbox'.
 		>>> shapes[3].shapeType
 		5
 
-  * `shapeTypeName`: a string representation of the type of shape as defined by shapeType. Read-only. 
+  * `shapeTypeName`: a string representation of the type of shape as defined by shapeType. Read-only.
 
 
 		>>> shapes[3].shapeTypeName
 		'POLYGON'
-		
+
   * `bbox`: If the shape type contains multiple points this tuple describes the
 	  lower left (x,y) coordinate and upper right corner coordinate creating a
 	  complete box around the points. If the shapeType is a
@@ -496,7 +496,7 @@ shapeType Point do not have a bounding box 'bbox'.
 		>>> ['%.3f' % coord for coord in shape]
 		['-122.471', '37.787']
 
-In most cases, however, if you need to do more than just type or bounds checking, you may want 
+In most cases, however, if you need to do more than just type or bounds checking, you may want
 to convert the geometry to the more human-readable [GeoJSON format](http://geojson.org),
 where lines and polygons are grouped for you:
 
@@ -505,7 +505,7 @@ where lines and polygons are grouped for you:
 	>>> geoj = s.__geo_interface__
 	>>> geoj["type"]
 	'MultiPolygon'
-	
+
 The results from the shapes() method similarly supports converting to GeoJSON:
 
 
@@ -514,12 +514,12 @@ The results from the shapes() method similarly supports converting to GeoJSON:
 
 Note: In some cases, if the conversion from shapefile geometry to GeoJSON encountered any problems
 or potential issues, a warning message will be displayed with information about the affected
-geometry. To ignore or suppress these warnings, you can disable this behavior by setting the 
-module constant VERBOSE to False: 
+geometry. To ignore or suppress these warnings, you can disable this behavior by setting the
+module constant VERBOSE to False:
 
 
 	>>> shapefile.VERBOSE = False
-	
+
 
 ### Reading Records
 
@@ -534,12 +534,12 @@ You can call the "fields" attribute of the shapefile as a Python list. Each
 field is a Python list with the following information:
 
   * Field name: the name describing the data at this column index.
-  * Field type: the type of data at this column index. Types can be: 
+  * Field type: the type of data at this column index. Types can be:
        * "C": Characters, text.
 	   * "N": Numbers, with or without decimals.
 	   * "F": Floats (same as "N").
-	   * "L": Logical, for boolean True/False values. 
-	   * "D": Dates. 
+	   * "L": Logical, for boolean True/False values.
+	   * "D": Dates.
 	   * "M": Memo, has no meaning within a GIS and is part of the xbase spec instead.
   * Field length: the length of the data found at this column index. Older GIS
 	   software may truncate this length to 8 or 11 characters for "Character"
@@ -571,11 +571,11 @@ attribute:
 	... ["UNITS3_9", "N", 8, 0], ["UNITS10_49", "N", 8, 0],
 	... ["UNITS50_UP", "N", 8, 0], ["MOBILEHOME", "N", 7, 0]]
 
-The first field of a dbf file is always a 1-byte field called "DeletionFlag", 
-which indicates records that have been deleted but not removed. However, 
-since this flag is very rarely used, PyShp currently will return all records  
-regardless of their deletion flag, and the flag is also not included in the list of 
-record values. In other words, the DeletionFlag field has no real purpose, and 
+The first field of a dbf file is always a 1-byte field called "DeletionFlag",
+which indicates records that have been deleted but not removed. However,
+since this flag is very rarely used, PyShp currently will return all records
+regardless of their deletion flag, and the flag is also not included in the list of
+record values. In other words, the DeletionFlag field has no real purpose, and
 should in most cases be ignored. For instance, to get a list of all fieldnames:
 
 
@@ -593,10 +593,10 @@ To read a single record call the record() method with the record's index:
 
 
 	>>> rec = sf.record(3)
-	
+
 Each record is a list-like Record object containing the values corresponding to each field in
 the field list (except the DeletionFlag). A record's values can be accessed by positional indexing or slicing.
-For example in the blockgroups shapefile the 2nd and 3rd fields are the blockgroup id 
+For example in the blockgroups shapefile the 2nd and 3rd fields are the blockgroup id
 and the 1990 population count of that San Francisco blockgroup:
 
 
@@ -604,7 +604,7 @@ and the 1990 population count of that San Francisco blockgroup:
 	['060750601001', 4715]
 
 For simpler access, the fields of a record can also accessed via the name of the field,
-either as a key or as an attribute name. The blockgroup id (BKG_KEY) of the blockgroups shapefile 
+either as a key or as an attribute name. The blockgroup id (BKG_KEY) of the blockgroups shapefile
 can also be retrieved as:
 
 
@@ -613,7 +613,7 @@ can also be retrieved as:
 
     >>> rec.BKG_KEY
     '060750601001'
-	
+
 The record values can be easily integrated with other programs by converting it to a field-value dictionary:
 
 
@@ -621,13 +621,13 @@ The record values can be easily integrated with other programs by converting it 
 	>>> sorted(dct.items())
 	[('AGE_18_29', 1467), ('AGE_30_49', 1681), ('AGE_50_64', 92), ('AGE_5_17', 848), ('AGE_65_UP', 30), ('AGE_UNDER5', 597), ('AMERI_ES', 6), ('AREA', 2.34385), ('ASIAN_PI', 452), ('BKG_KEY', '060750601001'), ('BLACK', 1007), ('DIVORCED', 149), ('FEMALES', 2095), ('FHH_CHILD', 16), ('HISPANIC', 416), ('HOUSEHOLDS', 1195), ('HSEHLD_1_F', 40), ('HSEHLD_1_M', 22), ('HSE_UNITS', 1258), ('MALES', 2620), ('MARHH_CHD', 79), ('MARHH_NO_C', 958), ('MARRIED', 2021), ('MEDIANRENT', 739), ('MEDIAN_VAL', 337500), ('MHH_CHILD', 0), ('MOBILEHOME', 0), ('NEVERMARRY', 703), ('OTHER', 288), ('OWNER_OCC', 66), ('POP1990', 4715), ('POP90_SQMI', 2011.6), ('RENTER_OCC', 3733), ('SEPARATED', 49), ('UNITS10_49', 49), ('UNITS2', 160), ('UNITS3_9', 672), ('UNITS50_UP', 0), ('UNITS_1ATT', 302), ('UNITS_1DET', 43), ('VACANT', 93), ('WHITE', 2962), ('WIDOWED', 37)]
 
-If at a later point you need to check the record's index position in the original 
+If at a later point you need to check the record's index position in the original
 shapefile, you can do this through the "oid" attribute:
 
 
 	>>> rec.oid
 	3
-	
+
 ### Reading Geometry and Records Simultaneously
 
 You may want to examine both the geometry and the attributes for a record at
@@ -663,13 +663,13 @@ To get the 4th shape record from the blockgroups shapefile use the third index:
 	>>> shapeRec = sf.shapeRecord(3)
 	>>> shapeRec.record[1:3]
 	['060750601001', 4715]
-	
+
 Each individual shape record also supports the _\_geo_interface\_\_ to convert it to a GeoJSON feature:
 
 
 	>>> shapeRec.__geo_interface__['type']
 	'Feature'
-	
+
 
 ## Writing Shapefiles
 
@@ -697,7 +697,7 @@ the file path and name to save to:
 
 	>>> w = shapefile.Writer('shapefiles/test/testfile')
 	>>> w.field('field1', 'C')
-	
+
 File extensions are optional when reading or writing shapefiles. If you specify
 them PyShp ignores them anyway. When you save files you can specify a base
 file name that is used for all three file types. Or you can specify a name for
@@ -706,9 +706,9 @@ one or more file types:
 
 	>>> w = shapefile.Writer(dbf='shapefiles/test/onlydbf.dbf')
 	>>> w.field('field1', 'C')
-	
+
 In that case, any file types not assigned will not
-save and only file types with file names will be saved. 
+save and only file types with file names will be saved.
 
 #### Writing Shapefiles to File-Like Objects
 
@@ -738,14 +738,14 @@ write to them:
 	>>> r = shapefile.Reader(shp=shp, shx=shx, dbf=dbf)
 	>>> len(r)
 	1
-	
-	
+
+
 
 #### Writing Shapefiles Using the Context Manager
 
 The "Writer" class automatically closes the open files and writes the final headers once it is garbage collected.
-In case of a crash and to make the code more readable, it is nevertheless recommended 
-you do this manually by calling the "close()" method: 
+In case of a crash and to make the code more readable, it is nevertheless recommended
+you do this manually by calling the "close()" method:
 
 
 	>>> w.close()
@@ -757,15 +757,15 @@ objects are properly closed and final headers written once you exit the with-cla
 	>>> with shapefile.Writer("shapefiles/test/contextwriter") as w:
 	... 	w.field('field1', 'C')
 	... 	pass
-	
+
 #### Setting the Shape Type
 
 The shape type defines the type of geometry contained in the shapefile. All of
 the shapes must match the shape type setting.
 
-There are three ways to set the shape type: 
-  * Set it when creating the class instance. 
-  * Set it by assigning a value to an existing class instance. 
+There are three ways to set the shape type:
+  * Set it when creating the class instance.
+  * Set it by assigning a value to an existing class instance.
   * Set it automatically to the type of the first non-null shape by saving the shapefile.
 
 To manually set the shape type for a Writer object when creating the Writer:
@@ -784,14 +784,14 @@ OR you can set it after the Writer is created:
 
 	>>> w.shapeType
 	1
-	
+
 
 ### Adding Records
 
-Before you can add records you must first create the fields that define what types of 
-values will go into each attribute. 
+Before you can add records you must first create the fields that define what types of
+values will go into each attribute.
 
-There are several different field types, all of which support storing None values as NULL. 
+There are several different field types, all of which support storing None values as NULL.
 
 Text fields are created using the 'C' type, and the third 'size' argument can be customized to the expected
 length of text values to save space:
@@ -804,12 +804,12 @@ length of text values to save space:
 	>>> w.null()
 	>>> w.record('Hello', 'World', 'World'*50)
 	>>> w.close()
-	
+
 	>>> r = shapefile.Reader('shapefiles/test/dtype')
 	>>> assert r.record(0) == ['Hello', 'World', 'World'*50]
 
-Date fields are created using the 'D' type, and can be created using either 
-date objects, lists, or a YYYYMMDD formatted string. 
+Date fields are created using the 'D' type, and can be created using either
+date objects, lists, or a YYYYMMDD formatted string.
 Field length or decimal have no impact on this type:
 
 
@@ -825,18 +825,18 @@ Field length or decimal have no impact on this type:
 	>>> w.record('19980130')
 	>>> w.record(None)
 	>>> w.close()
-	
+
 	>>> r = shapefile.Reader('shapefiles/test/dtype')
 	>>> assert r.record(0) == [date(1898,1,30)]
 	>>> assert r.record(1) == [date(1998,1,30)]
 	>>> assert r.record(2) == [date(1998,1,30)]
 	>>> assert r.record(3) == [None]
 
-Numeric fields are created using the 'N' type (or the 'F' type, which is exactly the same). 
-By default the fourth decimal argument is set to zero, essentially creating an integer field. 
-To store floats you must set the decimal argument to the precision of your choice. 
-To store very large numbers you must increase the field length size to the total number of digits 
-(including comma and minus). 
+Numeric fields are created using the 'N' type (or the 'F' type, which is exactly the same).
+By default the fourth decimal argument is set to zero, essentially creating an integer field.
+To store floats you must set the decimal argument to the precision of your choice.
+To store very large numbers you must increase the field length size to the total number of digits
+(including comma and minus).
 
 
 	>>> w = shapefile.Writer('shapefiles/test/dtype')
@@ -852,15 +852,15 @@ To store very large numbers you must increase the field length size to the total
 	>>> w.record(INT=nr, LOWPREC=nr, MEDPREC=nr, HIGHPREC=-3.2302e-25, FTYPE=nr, LARGENR=int(nr)*10**100)
 	>>> w.record(None, None, None, None, None, None)
 	>>> w.close()
-	
+
 	>>> r = shapefile.Reader('shapefiles/test/dtype')
 	>>> assert r.record(0) == [1, 1.32, 1.3217328, -3.2302e-25, 1.3217328, 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
 	>>> assert r.record(1) == [None, None, None, None, None, None]
 
-	
-Finally, we can create boolean fields by setting the type to 'L'. 
-This field can take True or False values, or 1 (True) or 0 (False). 
-None is interpreted as missing. 
+
+Finally, we can create boolean fields by setting the type to 'L'.
+This field can take True or False values, or 1 (True) or 0 (False).
+None is interpreted as missing.
 
 
 	>>> w = shapefile.Writer('shapefiles/test/dtype')
@@ -876,9 +876,9 @@ None is interpreted as missing.
 	>>> w.record(False)
 	>>> w.record(0)
 	>>> w.record(None)
-	>>> w.record("Nonesense")
+	>>> w.record("Nonsense")
 	>>> w.close()
-	
+
 	>>> r = shapefile.Reader('shapefiles/test/dtype')
 	>>> r.record(0)
 	Record #0: [True]
@@ -892,7 +892,7 @@ None is interpreted as missing.
 	Record #4: [None]
 	>>> r.record(5)
 	Record #5: [None]
-	
+
 You can also add attributes using keyword arguments where the keys are field names.
 
 
@@ -909,12 +909,12 @@ You can also add attributes using keyword arguments where the keys are field nam
 
 Geometry is added using one of several convenience methods. The "null" method is used
 for null shapes, "point" is used for point shapes, "multipoint" is used for multipoint shapes, "line" for lines,
-"poly" for polygons. 
+"poly" for polygons.
 
 **Adding a Null shape**
 
-A shapefile may contain some records for which geometry is not available, and may be set using the "null" method. 
-Because Null shape types (shape type 0) have no geometry the "null" method is called without any arguments. 
+A shapefile may contain some records for which geometry is not available, and may be set using the "null" method.
+Because Null shape types (shape type 0) have no geometry the "null" method is called without any arguments.
 
 
 	>>> w = shapefile.Writer('shapefiles/test/null')
@@ -928,59 +928,59 @@ Because Null shape types (shape type 0) have no geometry the "null" method is ca
 **Adding a Point shape**
 
 Point shapes are added using the "point" method. A point is specified by an x and
-y value. 
+y value.
 
 
 	>>> w = shapefile.Writer('shapefiles/test/point')
 	>>> w.field('name', 'C')
-	
-	>>> w.point(122, 37) 
+
+	>>> w.point(122, 37)
 	>>> w.record('point1')
-	
+
 	>>> w.close()
 
 **Adding a MultiPoint shape**
 
-If your point data allows for the possibility of multiple points per feature, use "multipoint" instead. 
-These are specified as a list of xy point coordinates. 
+If your point data allows for the possibility of multiple points per feature, use "multipoint" instead.
+These are specified as a list of xy point coordinates.
 
 
 	>>> w = shapefile.Writer('shapefiles/test/multipoint')
 	>>> w.field('name', 'C')
-	
-	>>> w.multipoint([[122,37], [124,32]]) 
+
+	>>> w.multipoint([[122,37], [124,32]])
 	>>> w.record('multipoint1')
-	
+
 	>>> w.close()
-	
+
 **Adding a LineString shape**
 
-For LineString shapefiles, each shape is given as a list of one or more linear features. 
-Each of the linear features must have at least two points. 
-	
-	
+For LineString shapefiles, each shape is given as a list of one or more linear features.
+Each of the linear features must have at least two points.
+
+
 	>>> w = shapefile.Writer('shapefiles/test/line')
 	>>> w.field('name', 'C')
-	
+
 	>>> w.line([
 	...			[[1,5],[5,5],[5,1],[3,3],[1,1]], # line 1
 	...			[[3,2],[2,6]] # line 2
 	...			])
-	
+
 	>>> w.record('linestring1')
-	
+
 	>>> w.close()
-	
+
 **Adding a Polygon shape**
 
 Similarly to LineString, Polygon shapes consist of multiple polygons, and must be given as a list of polygons.
-The main difference is that polygons must have at least 4 points and the last point must be the same as the first. 
+The main difference is that polygons must have at least 4 points and the last point must be the same as the first.
 It's also okay if you forget to repeat the first point at the end; PyShp automatically checks and closes the polygons
 if you don't.
 
 It's important to note that for Polygon shapefiles, your polygon coordinates must be ordered in a clockwise direction.
 If any of the polygons have holes, then the hole polygon coordinates must be ordered in a counterclockwise direction.
-The direction of your polygons determines how shapefile readers will distinguish between polygon outlines and holes. 
+The direction of your polygons determines how shapefile readers will distinguish between polygon outlines and holes.
 
 
 	>>> w = shapefile.Writer('shapefiles/test/polygon')
@@ -992,13 +992,13 @@ The direction of your polygons determines how shapefile readers will distinguish
 	...         [[15,2], [17,6], [22,7]]  # poly 2
 	...        ])
 	>>> w.record('polygon1')
-	
+
 	>>> w.close()
-		
+
 **Adding from an existing Shape object**
 
 Finally, geometry can be added by passing an existing "Shape" object to the "shape" method.
-You can also pass it any GeoJSON dictionary or _\_geo_interface\_\_ compatible object. 
+You can also pass it any GeoJSON dictionary or _\_geo_interface\_\_ compatible object.
 This can be particularly useful for copying from one file to another:
 
 
@@ -1011,14 +1011,14 @@ This can be particularly useful for copying from one file to another:
 	>>> for shaperec in r.iterShapeRecords():
 	...     w.record(*shaperec.record)
 	...     w.shape(shaperec.shape)
-	
+
 	>>> # or GeoJSON dicts
 	>>> for shaperec in r.iterShapeRecords():
 	...     w.record(*shaperec.record)
 	...     w.shape(shaperec.shape.__geo_interface__)
-	
-	>>> w.close()	
-	
+
+	>>> w.close()
+
 
 ### Geometry and Record Balancing
 
@@ -1027,17 +1027,17 @@ number of records equals the number of shapes to create a valid shapefile. You
 must take care to add records and shapes in the same order so that the record
 data lines up with the geometry data. For example:
 
-	
+
 	>>> w = shapefile.Writer('shapefiles/test/balancing', shapeType=shapefile.POINT)
 	>>> w.field("field1", "C")
 	>>> w.field("field2", "C")
-	
+
 	>>> w.record("row", "one")
 	>>> w.point(1, 1)
-	
+
 	>>> w.record("row", "two")
 	>>> w.point(2, 2)
-	
+
 To help prevent accidental misalignment PyShp has an "auto balance" feature to
 make sure when you add either a shape or a record the two sides of the
 equation line up. This way if you forget to update an entry the
@@ -1050,7 +1050,7 @@ the attribute autoBalance to 1 or True:
 	>>> w.record("row", "three")
 	>>> w.record("row", "four")
 	>>> w.point(4, 4)
-	
+
 	>>> w.recNum == w.shpNum
 	True
 
@@ -1059,7 +1059,7 @@ to ensure the other side is up to date. When balancing is used
 null shapes are created on the geometry side or records
 with a value of "NULL" for each field is created on the attribute side.
 This gives you flexibility in how you build the shapefile.
-You can create all of the shapes and then create all of the records or vice versa. 
+You can create all of the shapes and then create all of the records or vice versa.
 
 
     >>> w.autoBalance = 0
@@ -1069,16 +1069,16 @@ You can create all of the shapes and then create all of the records or vice vers
 	>>> w.point(5, 5)
 	>>> w.point(6, 6)
 	>>> w.balance()
-	
+
 	>>> w.recNum == w.shpNum
 	True
 
 If you do not use the autoBalance() or balance() method and forget to manually
 balance the geometry and attributes the shapefile will be viewed as corrupt by
 most shapefile software.
-	
+
 ### Writing .prj files
-A .prj file, or projection file, is a simple text file that stores a shapefile's map projection and coordinate reference system to help mapping software properly locate the geometry on a map. If you don't have one, you may get confusing errors when you try and use the shapefile you created. The GIS software may complain that it doesn't know the shapefile's projection and refuse to accept it, it may assume the shapefile is the same projection as the rest of your GIS project and put it in the wrong place, or it might assume the coordinates are an offset in meters from latitude and longitude 0,0 which will put your data in the middle of the ocean near Africa. The text in the .prj file is a [Well-Known-Text (WKT) projection string](https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems). Projection strings can be quite long so they are often referenced using numeric codes call EPSG codes. The .prj file must have the same base name as your shapefile. So for example if you have a shapefile named "myPoints.shp", the .prj file must be named "myPoints.prj". 
+A .prj file, or projection file, is a simple text file that stores a shapefile's map projection and coordinate reference system to help mapping software properly locate the geometry on a map. If you don't have one, you may get confusing errors when you try and use the shapefile you created. The GIS software may complain that it doesn't know the shapefile's projection and refuse to accept it, it may assume the shapefile is the same projection as the rest of your GIS project and put it in the wrong place, or it might assume the coordinates are an offset in meters from latitude and longitude 0,0 which will put your data in the middle of the ocean near Africa. The text in the .prj file is a [Well-Known-Text (WKT) projection string](https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems). Projection strings can be quite long so they are often referenced using numeric codes call EPSG codes. The .prj file must have the same base name as your shapefile. So for example if you have a shapefile named "myPoints.shp", the .prj file must be named "myPoints.prj".
 
 If you're using the same projection over and over, the following is a simple way to create the .prj file assuming your base filename is stored in a variable called "filename":
 
@@ -1092,17 +1092,17 @@ If you're using the same projection over and over, the following is a simple way
 	    prj.write(wkt)
 ```
 
-If you need to dynamically fetch WKT projection strings, you can use the pure Python [PyCRS](https://github.com/karimbahgat/PyCRS) module which has a number of useful features. 
+If you need to dynamically fetch WKT projection strings, you can use the pure Python [PyCRS](https://github.com/karimbahgat/PyCRS) module which has a number of useful features.
 
 # Advanced Use
 
 ## Common Errors and Fixes
 
-Below we list some commonly encountered errors and ways to fix them. 
+Below we list some commonly encountered errors and ways to fix them.
 
 ### Warnings and Logging
 
-By default, PyShp chooses to be transparent and provide the user with logging information and warnings about non-critical issues when reading or writing shapefiles. This behavior is controlled by the module constant `VERBOSE` (which defaults to True). If you would rather suppress this information, you can simply set this to False: 
+By default, PyShp chooses to be transparent and provide the user with logging information and warnings about non-critical issues when reading or writing shapefiles. This behavior is controlled by the module constant `VERBOSE` (which defaults to True). If you would rather suppress this information, you can simply set this to False:
 
 
 	>>> shapefile.VERBOSE = False
@@ -1115,21 +1115,21 @@ All logging happens under the namespace `shapefile`. So another way to suppress 
 
 ### Shapefile Encoding Errors
 
-PyShp supports reading and writing shapefiles in any language or character encoding, and provides several options for decoding and encoding text. 
-Most shapefiles are written in UTF-8 encoding, PyShp's default encoding, so in most cases you don't have to specify the encoding. 
-If you encounter an encoding error when reading a shapefile, this means the shapefile was likely written in a non-utf8 encoding. 
+PyShp supports reading and writing shapefiles in any language or character encoding, and provides several options for decoding and encoding text.
+Most shapefiles are written in UTF-8 encoding, PyShp's default encoding, so in most cases you don't have to specify the encoding.
+If you encounter an encoding error when reading a shapefile, this means the shapefile was likely written in a non-utf8 encoding.
 For instance, when working with English language shapefiles, a common reason for encoding errors is that the shapefile was written in Latin-1 encoding.
-For reading shapefiles in any non-utf8 encoding, such as Latin-1, just 
-supply the encoding option when creating the Reader class. 
+For reading shapefiles in any non-utf8 encoding, such as Latin-1, just
+supply the encoding option when creating the Reader class.
 
 
 	>>> r = shapefile.Reader("shapefiles/test/latin1.shp", encoding="latin1")
 	>>> r.record(0) == [2, u'Ñandú']
 	True
-	
-Once you have loaded the shapefile, you may choose to save it using another more supportive encoding such 
-as UTF-8. Assuming the new encoding supports the characters you are trying to write, reading it back in 
-should give you the same unicode string you started with. 
+
+Once you have loaded the shapefile, you may choose to save it using another more supportive encoding such
+as UTF-8. Assuming the new encoding supports the characters you are trying to write, reading it back in
+should give you the same unicode string you started with.
 
 
 	>>> w = shapefile.Writer("shapefiles/test/latin_as_utf8.shp", encoding="utf8")
@@ -1137,15 +1137,15 @@ should give you the same unicode string you started with.
 	>>> w.record(*r.record(0))
 	>>> w.null()
 	>>> w.close()
-	
+
 	>>> r = shapefile.Reader("shapefiles/test/latin_as_utf8.shp", encoding="utf8")
 	>>> r.record(0) == [2, u'Ñandú']
 	True
-	
+
 If you supply the wrong encoding and the string is unable to be decoded, PyShp will by default raise an
 exception. If however, on rare occasion, you are unable to find the correct encoding and want to ignore
 or replace encoding errors, you can specify the "encodingErrors" to be used by the decode method. This
-applies to both reading and writing. 
+applies to both reading and writing.
 
 
 	>>> r = shapefile.Reader("shapefiles/test/latin1.shp", encoding="ascii", encodingErrors="replace")
@@ -1156,8 +1156,8 @@ applies to both reading and writing.
 
 ## Reading Large Shapefiles
 
-Despite being a lightweight library, PyShp is designed to be able to read shapefiles of any size, allowing you to work with hundreds of thousands or even millions 
-of records and complex geometries. 
+Despite being a lightweight library, PyShp is designed to be able to read shapefiles of any size, allowing you to work with hundreds of thousands or even millions
+of records and complex geometries.
 
 ### Iterating through a shapefile
 
@@ -1167,22 +1167,22 @@ As an example, let's load this Natural Earth shapefile of more than 4000 global 
 	>>> sf = shapefile.Reader("https://github.com/nvkelso/natural-earth-vector/blob/master/10m_cultural/ne_10m_admin_1_states_provinces?raw=true")
 
 When first creating the Reader class, the library only reads the header information
-and leaves the rest of the file contents alone. Once you call the records() and shapes() 
-methods however, it will attempt to read the entire file into memory at once. 
+and leaves the rest of the file contents alone. Once you call the records() and shapes()
+methods however, it will attempt to read the entire file into memory at once.
 For very large files this can result in MemoryError. So when working with large files
 it is recommended to use instead the iterShapes(), iterRecords(), or iterShapeRecords()
-methods instead. These iterate through the file contents one at a time, enabling you to loop 
-through them while keeping memory usage at a minimum. 
+methods instead. These iterate through the file contents one at a time, enabling you to loop
+through them while keeping memory usage at a minimum.
 
 
 	>>> for shape in sf.iterShapes():
 	...     # do something here
 	...     pass
-	
+
 	>>> for rec in sf.iterRecords():
 	...     # do something here
 	...     pass
-	
+
 	>>> for shapeRec in sf.iterShapeRecords():
 	...     # do something here
 	...     pass
@@ -1202,7 +1202,7 @@ By default when reading the attribute records of a shapefile, pyshp unpacks and 
 	... 	pass
 	>>> rec
 	Record #4595: ['Birgu', 'Malta']
-	
+
 ### Attribute filtering
 
 In many cases, we aren't interested in all entries of a shapefile, but rather only want to retrieve a small subset of records by filtering on some attribute. To avoid wasting time reading records and shapes that we don't need, we can start by iterating only the records and fields of interest, check if the record matches some condition as a way to filter the data, and finally load the full record and shape geometry for those that meet the condition:
@@ -1222,7 +1222,7 @@ In many cases, we aren't interested in all entries of a shapefile, but rather on
 	'Maekel'
 	'Anseba'
 
-Selectively reading only the necessary data in this way is particularly useful for efficiently processing a limited subset of data from very large files or when looping through a large number of files, especially if they contain large attribute tables or complex shape geometries. 
+Selectively reading only the necessary data in this way is particularly useful for efficiently processing a limited subset of data from very large files or when looping through a large number of files, especially if they contain large attribute tables or complex shape geometries.
 
 ### Spatial filtering
 
@@ -1253,23 +1253,23 @@ Another common use-case is that we only want to read those records that are loca
 	Record #2037: ['Al Hudaydah', 'Yemen']
 	Record #3741: ['Anseba', 'Eritrea']
 
-This functionality means that shapefiles can be used as a bare-bones spatially indexed database, with very fast bounding box queries for even the largest of shapefiles. Note that, as with all spatial indexing, this method does not guarantee that the *geometries* of the resulting matches overlap the queried region, only that their *bounding boxes* overlap. 
+This functionality means that shapefiles can be used as a bare-bones spatially indexed database, with very fast bounding box queries for even the largest of shapefiles. Note that, as with all spatial indexing, this method does not guarantee that the *geometries* of the resulting matches overlap the queried region, only that their *bounding boxes* overlap.
 
 
 
 ## Writing large shapefiles
 
-Similar to the Reader class, the shapefile Writer class uses a streaming approach to keep memory 
-usage at a minimum and allow writing shapefiles of arbitrarily large sizes. The library takes care of this under-the-hood by immediately 
-writing each geometry and record to disk the moment they 
-are added using shape() or record(). Once the writer is closed, exited, or garbage 
-collected, the final header information is calculated and written to the beginning of 
-the file. 
+Similar to the Reader class, the shapefile Writer class uses a streaming approach to keep memory
+usage at a minimum and allow writing shapefiles of arbitrarily large sizes. The library takes care of this under-the-hood by immediately
+writing each geometry and record to disk the moment they
+are added using shape() or record(). Once the writer is closed, exited, or garbage
+collected, the final header information is calculated and written to the beginning of
+the file.
 
 ### Merging multiple shapefiles
 
-This means that it's possible to merge hundreds or thousands of shapefiles, as 
-long as you iterate through the source files to avoid loading everything into 
+This means that it's possible to merge hundreds or thousands of shapefiles, as
+long as you iterate through the source files to avoid loading everything into
 memory. The following example copies the contents of a shapefile to a new file 10 times:
 
 	>>> # create writer
@@ -1295,12 +1295,12 @@ memory. The following example copies the contents of a shapefile to a new file 1
 	>>> # close the writer
 	>>> w.close()
 
-In this trivial example, we knew that all files had the exact same field names, ordering, and types. In other scenarios, you will have to additionally make sure that all shapefiles have the exact same fields in the same order, and that they all contain the same geometry type. 
+In this trivial example, we knew that all files had the exact same field names, ordering, and types. In other scenarios, you will have to additionally make sure that all shapefiles have the exact same fields in the same order, and that they all contain the same geometry type.
 
 ### Editing shapefiles
 
-If you need to edit a shapefile you would have to read the 
-file one record at a time, modify or filter the contents, and write it back out. For instance, to create a copy of a shapefile that only keeps a subset of relevant fields: 
+If you need to edit a shapefile you would have to read the
+file one record at a time, modify or filter the contents, and write it back out. For instance, to create a copy of a shapefile that only keeps a subset of relevant fields:
 
 	>>> # create writer
 	>>> w = shapefile.Writer('shapefiles/test/edit')
@@ -1325,7 +1325,7 @@ file one record at a time, modify or filter the contents, and write it back out.
 ## 3D and Other Geometry Types
 
 Most shapefiles store conventional 2D points, lines, or polygons. But the shapefile format is also capable
-of storing various other types of geometries as well, including complex 3D surfaces and objects. 
+of storing various other types of geometries as well, including complex 3D surfaces and objects.
 
 ### Shapefiles with measurement (M) values
 
@@ -1338,107 +1338,107 @@ or by simply omitting the third M-coordinate.
 
 	>>> w = shapefile.Writer('shapefiles/test/linem')
 	>>> w.field('name', 'C')
-	
+
 	>>> w.linem([
 	...			[[1,5,0],[5,5],[5,1,3],[3,3,None],[1,1,0]], # line with one omitted and one missing M-value
 	...			[[3,2],[2,6]] # line without any M-values
 	...			])
-	
+
 	>>> w.record('linem1')
-	
+
 	>>> w.close()
-	
+
 Shapefiles containing M-values can be examined in several ways:
 
 	>>> r = shapefile.Reader('shapefiles/test/linem')
-	
+
 	>>> r.mbox # the lower and upper bound of M-values in the shapefile
 	[0.0, 3.0]
-	
+
 	>>> r.shape(0).m # flat list of M-values
 	[0.0, None, 3.0, None, 0.0, None, None]
 
-	
+
 ### Shapefiles with elevation (Z) values
 
-Elevation shape types are shapes that include an elevation value at each vertex, for instance elevation from a GPS device. 
-Shapes with elevation (Z) values are added with the following methods: "pointz", "multipointz", "linez", and "polyz". 
+Elevation shape types are shapes that include an elevation value at each vertex, for instance elevation from a GPS device.
+Shapes with elevation (Z) values are added with the following methods: "pointz", "multipointz", "linez", and "polyz".
 The Z-values are specified by adding a third Z value to each XY coordinate. Z-values do not support the concept of missing data,
 but if you omit the third Z-coordinate it will default to 0. Note that Z-type shapes also support measurement (M) values added
-as a fourth M-coordinate. This too is optional. 
-	
-	
+as a fourth M-coordinate. This too is optional.
+
+
 	>>> w = shapefile.Writer('shapefiles/test/linez')
 	>>> w.field('name', 'C')
-	
+
 	>>> w.linez([
 	...			[[1,5,18],[5,5,20],[5,1,22],[3,3],[1,1]], # line with some omitted Z-values
 	...			[[3,2],[2,6]], # line without any Z-values
 	...			[[3,2,15,0],[2,6,13,3],[1,9,14,2]] # line with both Z- and M-values
 	...			])
-	
+
 	>>> w.record('linez1')
-	
+
 	>>> w.close()
-	
+
 To examine a Z-type shapefile you can do:
 
 	>>> r = shapefile.Reader('shapefiles/test/linez')
-	
+
 	>>> r.zbox # the lower and upper bound of Z-values in the shapefile
 	[0.0, 22.0]
-	
+
 	>>> r.shape(0).z # flat list of Z-values
 	[18.0, 20.0, 22.0, 0.0, 0.0, 0.0, 0.0, 15.0, 13.0, 14.0]
 
 ### 3D MultiPatch Shapefiles
 
-Multipatch shapes are useful for storing composite 3-Dimensional objects. 
+Multipatch shapes are useful for storing composite 3-Dimensional objects.
 A MultiPatch shape represents a 3D object made up of one or more surface parts.
 Each surface in "parts" is defined by a list of XYZM values (Z and M values optional), and its corresponding type is
-given in the "partTypes" argument. The part type decides how the coordinate sequence is to be interpreted, and can be one 
+given in the "partTypes" argument. The part type decides how the coordinate sequence is to be interpreted, and can be one
 of the following module constants: TRIANGLE_STRIP, TRIANGLE_FAN, OUTER_RING, INNER_RING, FIRST_RING, or RING.
-For instance, a TRIANGLE_STRIP may be used to represent the walls of a building, combined with a TRIANGLE_FAN to represent 
-its roof: 
+For instance, a TRIANGLE_STRIP may be used to represent the walls of a building, combined with a TRIANGLE_FAN to represent
+its roof:
 
 	>>> from shapefile import TRIANGLE_STRIP, TRIANGLE_FAN
-	
+
 	>>> w = shapefile.Writer('shapefiles/test/multipatch')
 	>>> w.field('name', 'C')
-	
+
 	>>> w.multipatch([
 	...				 [[0,0,0],[0,0,3],[5,0,0],[5,0,3],[5,5,0],[5,5,3],[0,5,0],[0,5,3],[0,0,0],[0,0,3]], # TRIANGLE_STRIP for house walls
 	...				 [[2.5,2.5,5],[0,0,3],[5,0,3],[5,5,3],[0,5,3],[0,0,3]], # TRIANGLE_FAN for pointed house roof
 	...				 ],
 	...				 partTypes=[TRIANGLE_STRIP, TRIANGLE_FAN]) # one type for each part
-	
+
 	>>> w.record('house1')
-	
+
 	>>> w.close()
-	
+
 For an introduction to the various multipatch part types and examples of how to create 3D MultiPatch objects see [this
-ESRI White Paper](http://downloads.esri.com/support/whitepapers/ao_/J9749_MultiPatch_Geometry_Type.pdf). 
+ESRI White Paper](http://downloads.esri.com/support/whitepapers/ao_/J9749_MultiPatch_Geometry_Type.pdf).
 
 
-	
+
 # Testing
 
-The testing framework is pytest, and the tests are located in test_shapefile.py. 
-This includes an extensive set of unit tests of the various pyshp features, 
-and tests against various input data. Some of the tests that require 
-internet connectivity will be skipped in offline testing environments. 
-In the same folder as README.md and shapefile.py, from the command line run 
+The testing framework is pytest, and the tests are located in test_shapefile.py.
+This includes an extensive set of unit tests of the various pyshp features,
+and tests against various input data. Some of the tests that require
+internet connectivity will be skipped in offline testing environments.
+In the same folder as README.md and shapefile.py, from the command line run
 ```
 $ python -m pytest
-``` 
+```
 
-Additionally, all the code and examples located in this file, README.md, 
+Additionally, all the code and examples located in this file, README.md,
 is tested and verified with the builtin doctest framework.
 A special routine for invoking the doctest is run when calling directly on shapefile.py.
-In the same folder as README.md and shapefile.py, from the command line run 
+In the same folder as README.md and shapefile.py, from the command line run
 ```
 $ python shapefile.py
-``` 
+```
 
 Linux/Mac and similar platforms will need to run `$ dos2unix README.md` in order
 to correct line endings in README.md.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@ VERSION 2.3.0
 
 2022-04-30
 	New Features:
-	* Added support for pathlib and path-like shapefile filepaths (@mwtoews). 
+	* Added support for pathlib and path-like shapefile filepaths (@mwtoews).
 	* Allow reading individual file extensions via filepaths.
 
 	Improvements:
@@ -21,7 +21,7 @@ VERSION 2.3.0
 	* More robust handling of corrupt shapefiles (fixes #235)
 	* Fix errors when writing to individual file-handles (fixes #237)
 	* Revert previous decision to enforce geojson output ring orientation (detailed explanation at https://github.com/SciTools/cartopy/issues/2012)
-	* Fix test issues in environments without network access (@sebastic, @musicinmybrain). 
+	* Fix test issues in environments without network access (@sebastic, @musicinmybrain).
 
 VERSION 2.2.0
 
@@ -33,7 +33,7 @@ VERSION 2.2.0
 	* Allow fast filtering which shapes to read from the file through a `bbox` arg.
 
 	Improvements:
-	* More examples and restructuring of README. 
+	* More examples and restructuring of README.
 	* More informative Shape to geojson warnings (see #219).
 	* Add shapefile.VERBOSE flag to control warnings verbosity (default True).
 	* Shape object information when calling repr().
@@ -88,7 +88,7 @@ VERSION 2.1.0
 
 2019-02-15
 	New Features:
-	* Added back read/write support for unicode field names. 
+	* Added back read/write support for unicode field names.
 	* Improved Record representation
 	* More support for geojson on Reader, ShapeRecord, ShapeRecords, and shapes()
 
@@ -100,54 +100,54 @@ VERSION 2.1.0
 VERSION 2.0.1
 
 2018-11-05
-	* Fix pip install setup.py README decoding error. 
+	* Fix pip install setup.py README decoding error.
 
 VERSION 2.0.0
 
 2018-09-01
 	(Note: Some contributor attributions may be missing.)
 	New Features:
-	* Full support for unicode text, with custom encoding, and exception handling. 
-	  - Means that the Reader returns unicode, and the Writer accepts unicode. 
-	* PyShp has been simplified to a pure input-output library using the Reader and Writer classes, dropping the Editor class. 
+	* Full support for unicode text, with custom encoding, and exception handling.
+	  - Means that the Reader returns unicode, and the Writer accepts unicode.
+	* PyShp has been simplified to a pure input-output library using the Reader and Writer classes, dropping the Editor class.
 	* Switched to a new streaming approach when writing files, keeping memory-usage at a minimum:
-	  - Specify filepath/destination and text encoding when creating the Writer. 
-	  - The file is written incrementally with each call to shape/record. 
-	  - Adding shapes is now done using dedicated methods for each shapetype. 
+	  - Specify filepath/destination and text encoding when creating the Writer.
+	  - The file is written incrementally with each call to shape/record.
+	  - Adding shapes is now done using dedicated methods for each shapetype.
 	* Reading shapefiles is now more convenient:
-	  - Shapefiles can be opened using the context manager, and files are properly closed. 
-	  - Shapefiles can be iterated, have a length, and supports the geo interface. 
+	  - Shapefiles can be opened using the context manager, and files are properly closed.
+	  - Shapefiles can be iterated, have a length, and supports the geo interface.
 	  - New ways of inspecing shapefile metadata by printing. [@megies]
 	  - More convenient accessing of Record values as attributes. [@philippkraft]
-	  - More convenient shape type name checking. [@megies] 
-	* Add more support and documentation for MultiPatch 3D shapes. 
-	* The Reader "elevation" and "measure" attributes now renamed "zbox" and "mbox", to make it clear they refer to the min/max values. 
-	* Better documentation of previously unclear aspects, such as field types. 
+	  - More convenient shape type name checking. [@megies]
+	* Add more support and documentation for MultiPatch 3D shapes.
+	* The Reader "elevation" and "measure" attributes now renamed "zbox" and "mbox", to make it clear they refer to the min/max values.
+	* Better documentation of previously unclear aspects, such as field types.
 
 	Bug Fixes:
 	* More reliable/robust:
 	  - Fixed shapefile bbox error for empty or point type shapefiles. [@mcuprjak]
 	  - Reading and writing Z and M type shapes is now more robust, fixing many errors, and has been added to the documentation. [@ShinNoNoir]
-	  - Improved parsing of field value types, fixed errors and made more flexible. 
+	  - Improved parsing of field value types, fixed errors and made more flexible.
 	  - Fixed bug when writing shapefiles with datefield and date values earlier than 1900 [@megies]
 	* Fix some geo interface errors, including checking polygon directions.
 	* Bug fixes for reading from case sensitive file names, individual files separately, and from file-like objects. [@gastoneb, @kb003308, @erickskb]
 	* Enforce maximum field limit. [@mwtoews]
-	
+
 VERSION 1.2.12
 	* ?
-	
+
 VERSION 1.2.11
 
 2017-04-29 Karim Bahgat <karim.bahgat.norway@gmail.com>
-	* Fixed bugs when reading and writing empty shapefiles. 
+	* Fixed bugs when reading and writing empty shapefiles.
 	* Fixed bug when writing null geometry.
 	* Fixed misc data type errors.
 	* Fixed error when reading files with wrong record length.
-	* Use max field precision when saving decimal numbers. 
-	* Improved shapetype detection. 
-	* Expanded docs on data types. 
-	* General doc additions and travis icon. 
+	* Use max field precision when saving decimal numbers.
+	* Improved shapetype detection.
+	* Expanded docs on data types.
+	* General doc additions and travis icon.
 
 VERSION 1.2.10
 
@@ -162,7 +162,7 @@ VERSION 1.2.9
 VERSION 1.2.8
 
 2016-08-17 Joel Lawhead <jlawhead@geospatialpython.com>
-	* Configured Travis-CI 
+	* Configured Travis-CI
 
 VERSION 1.2.5
 
@@ -171,7 +171,7 @@ VERSION 1.2.5
 	* Merge README text into markdown file. Remove text version.
 	* Fixed parsing of number of points for some shapes (MULTIPOINTM, MULTIPOINTZ)
 
-VERSON 1.2.3
+VERSION 1.2.3
 
 2015-06-21 Joel Lawhead <jlawhead@geospatialpython.com>
 	*shapefile.py (u) Bugfix for Python3 with Reader.iterShapeRecords()
@@ -211,9 +211,9 @@ VERSION 1.2.0
 	*README.txt add example/test for writing a 3D polygon
 
 VERSION 1.1.9
-	
+
 2013-07-27 Joel Lawhead <jlawhead@geospatialpython.com>
-	*shapefile.py (Writer.__shpRecords) fixed inconsistency between Reader and Writer 
+	*shapefile.py (Writer.__shpRecords) fixed inconsistency between Reader and Writer
 	when referencing "z" and "m" values.  This bug caused errors only when editing
 	3D shapefiles.
 
@@ -233,39 +233,39 @@ VERSION 1.1.7
 
 2013-06-22 Joel Lawhead <jlawhead@geospatialpython.com>
 
-	*shapefile.py (_Shape.__geo_interface__) Added Python __geo_interface__ convention 
+	*shapefile.py (_Shape.__geo_interface__) Added Python __geo_interface__ convention
 	to export shapefiles as GeoJSON.
-	
-	*shapefile.py (Reader.__init__) Used is_string() method to detect filenames passed 
+
+	*shapefile.py (Reader.__init__) Used is_string() method to detect filenames passed
 	as unicode strings.
-	
-	*shapefile.py (Reader.iterShapes) Added iterShapes() method to iterate through 
+
+	*shapefile.py (Reader.iterShapes) Added iterShapes() method to iterate through
 	geometry records for parsing large files efficiently.
-	
-	*shapefile.py (Reader.iterRecords) Added iterRecords() method to iterate through 
+
+	*shapefile.py (Reader.iterRecords) Added iterRecords() method to iterate through
 	dbf records efficiently in large files.
-	
-	*shapefile.py (Reader.shape) Modified shape() method to use iterShapes() if shx 
+
+	*shapefile.py (Reader.shape) Modified shape() method to use iterShapes() if shx
 	file is not available.
-	
+
 	*shapefile.py (main) Added __version__ attribute.
-	
-	*shapefile.py (Writer.record) Fixed bug which prevents writing the number 0 to 
+
+	*shapefile.py (Writer.record) Fixed bug which prevents writing the number 0 to
 	dbf fields.
 
 	*shapefile.py (Reader.__shape) Updated to calculate and seek the start of the next record. The
 	shapefile spec does not require the content of a geometry record to be as long as the content
-	length defined in the header.  The result is you can delete features without modifying the 
+	length defined in the header.  The result is you can delete features without modifying the
 	record header allowing for empty space in records.
-	
+
 	*shapefile.py (Writer.poly) Added enforcement of closed polygons
-	
+
 	*shapefile.py (Writer.save) Added unique file name generator to use if no file names are passed
 	to a writer instance when saving (ex. w.save()).  The unique file name is returned as a string.
-	
+
 	*README.txt (main) Added tests for iterShapes(), iterRecords(), __geo_interface__()
-	
+
 	*README.txt (main) Updated "bbox" property documentation to match Esri specification.
 
-	
-	
+
+

--- a/shapefile.py
+++ b/shapefile.py
@@ -85,7 +85,7 @@ if PYTHON3:
     from urllib.parse import urlparse, urlunparse
     from urllib.error import HTTPError
     from urllib.request import urlopen, Request
-    
+
 else:
     from itertools import izip
 
@@ -97,7 +97,7 @@ else:
 # Helpers
 
 MISSING = [None,'']
-NODATA = -10e38 # as per the ESRI shapefile spec, only used for m-values. 
+NODATA = -10e38 # as per the ESRI shapefile spec, only used for m-values.
 
 if PYTHON3:
     def b(v, encoding='utf-8', encodingErrors='strict'):
@@ -207,7 +207,7 @@ def signed_area(coords, fast=False):
 
 def is_cw(coords):
     """Returns True if a polygon ring has clockwise orientation, determined
-    by a negatively signed area. 
+    by a negatively signed area.
     """
     area2 = signed_area(coords, fast=True)
     return area2 < 0
@@ -245,7 +245,7 @@ def ring_contains_point(coords, p):
 
     Adapted from code by Eric Haynes
     http://www.realtimerendering.com/resources/GraphicsGems//gemsiv/ptpoly_haines/ptinpoly.c
-    
+
     Original description:
         Shoot a test ray along +X axis.  The strategy, from MacMartin, is to
         compare vertex Y values to the testing point's Y and quickly discard
@@ -258,11 +258,11 @@ def ring_contains_point(coords, p):
     yflag0 = ( vtx0[1] >= ty )
 
     inside_flag = False
-    for vtx1 in coords[1:]: 
+    for vtx1 in coords[1:]:
         yflag1 = ( vtx1[1] >= ty )
         # check if endpoints straddle (are on opposite sides) of X axis
         # (i.e. the Y's differ); if so, +X ray could intersect this edge.
-        if yflag0 != yflag1: 
+        if yflag0 != yflag1:
             xflag0 = ( vtx0[0] >= tx )
             # check if endpoints are on same side of the Y axis (i.e. X's
             # are the same); if so, it's easy to test if edge hits or misses.
@@ -287,7 +287,7 @@ def ring_sample(coords, ccw=False):
     finding the first centroid of a coordinate triplet whose orientation
     matches the orientation of the ring and passes the point-in-ring test.
     The orientation of the ring is assumed to be clockwise, unless ccw
-    (counter-clockwise) is set to True. 
+    (counter-clockwise) is set to True.
     """
     triplet = []
     def itercoords():
@@ -296,12 +296,12 @@ def ring_sample(coords, ccw=False):
             yield p
         # finally, yield the second coordinate to the end to allow checking the last triplet
         yield coords[1]
-        
-    for p in itercoords(): 
+
+    for p in itercoords():
         # add point to triplet (but not if duplicate)
         if p not in triplet:
             triplet.append(p)
-            
+
         # new triplet, try to get sample
         if len(triplet) == 3:
             # check that triplet does not form a straight line (not a triangle)
@@ -322,26 +322,26 @@ def ring_sample(coords, ccw=False):
             # failed to get sample point from this triplet
             # remove oldest triplet coord to allow iterating to next triplet
             triplet.pop(0)
-            
+
     else:
         raise Exception('Unexpected error: Unable to find a ring sample point.')
 
 def ring_contains_ring(coords1, coords2):
-    '''Returns True if all vertexes in coords2 are fully inside coords1.
+    '''Returns True if all vertices in coords2 are fully inside coords1.
     '''
     return all((ring_contains_point(coords1, p2) for p2 in coords2))
 
 def organize_polygon_rings(rings, return_errors=None):
     '''Organize a list of coordinate rings into one or more polygons with holes.
     Returns a list of polygons, where each polygon is composed of a single exterior
-    ring, and one or more interior holes. If a return_errors dict is provided (optional), 
-    any errors encountered will be added to it. 
+    ring, and one or more interior holes. If a return_errors dict is provided (optional),
+    any errors encountered will be added to it.
 
     Rings must be closed, and cannot intersect each other (non-self-intersecting polygon).
     Rings are determined as exteriors if they run in clockwise direction, or interior
     holes if they run in counter-clockwise direction. This method is used to construct
     GeoJSON (multi)polygons from the shapefile polygon shape type, which does not
-    explicitly store the structure of the polygons beyond exterior/interior ring orientation. 
+    explicitly store the structure of the polygons beyond exterior/interior ring orientation.
     '''
     # first iterate rings and classify as exterior or hole
     exteriors = []
@@ -355,7 +355,7 @@ def organize_polygon_rings(rings, return_errors=None):
         else:
             # ring is a hole
             holes.append(ring)
-                
+
     # if only one exterior, then all holes belong to that exterior
     if len(exteriors) == 1:
         # exit early
@@ -374,7 +374,7 @@ def organize_polygon_rings(rings, return_errors=None):
                 poly = [ext]
                 polys.append(poly)
             return polys
-        
+
         # first determine each hole's candidate exteriors based on simple bbox contains test
         hole_exteriors = dict([(hole_i,[]) for hole_i in xrange(len(holes))])
         exterior_bboxes = [ring_bbox(ring) for ring in exteriors]
@@ -386,7 +386,7 @@ def organize_polygon_rings(rings, return_errors=None):
 
         # then, for holes with still more than one possible exterior, do more detailed hole-in-ring test
         for hole_i,exterior_candidates in hole_exteriors.items():
-            
+
             if len(exterior_candidates) > 1:
                 # get hole sample point
                 ccw = not is_cw(holes[hole_i])
@@ -404,7 +404,7 @@ def organize_polygon_rings(rings, return_errors=None):
 
         # if still holes with more than one possible exterior, means we have an exterior hole nested inside another exterior's hole
         for hole_i,exterior_candidates in hole_exteriors.items():
-            
+
             if len(exterior_candidates) > 1:
                 # exterior candidate with the smallest area is the hole's most immediate parent
                 ext_i = sorted(exterior_candidates, key=lambda x: abs(signed_area(exteriors[x], fast=True)))[0]
@@ -463,17 +463,17 @@ class Shape(object):
         geometry record then those shapes are called parts. Parts
         are designated by their starting index in geometry record's
         list of shapes. For MultiPatch geometry, partTypes designates
-        the patch type of each of the parts. 
+        the patch type of each of the parts.
         """
         self.shapeType = shapeType
         self.points = points or []
         self.parts = parts or []
         if partTypes:
             self.partTypes = partTypes
-        
+
         # and a dict to silently record any errors encountered
         self._errors = {}
-        
+
         # add oid
         if oid is not None:
             self.__oid = oid
@@ -557,12 +557,12 @@ class Shape(object):
                     rings.append(ring)
 
                 # organize rings into list of polygons, where each polygon is defined as list of rings.
-                # the first ring is the exterior and any remaining rings are holes (same as GeoJSON). 
+                # the first ring is the exterior and any remaining rings are holes (same as GeoJSON).
                 polys = organize_polygon_rings(rings, self._errors)
-                
+
                 # if VERBOSE is True, issue detailed warning about any shape errors
                 # encountered during the Shapefile to GeoJSON conversion
-                if VERBOSE and self._errors: 
+                if VERBOSE and self._errors:
                     header = 'Possible issue encountered when converting Shape #{} to GeoJSON: '.format(self.oid)
                     orphans = self._errors.get('polygon_orphaned_holes', None)
                     if orphans:
@@ -616,7 +616,7 @@ still included but were encoded as GeoJSON exterior rings instead of holes.'
         else:
             raise Exception("Cannot create Shape from GeoJSON type '%s'" % geojType)
         shape.shapeType = shapeType
-        
+
         # set points and parts
         if geojType == "Point":
             shape.points = [ geoj["coordinates"] ]
@@ -629,9 +629,9 @@ still included but were encoded as GeoJSON exterior rings instead of holes.'
             parts = []
             index = 0
             for i,ext_or_hole in enumerate(geoj["coordinates"]):
-                # although the latest GeoJSON spec states that exterior rings should have 
-                # counter-clockwise orientation, we explicitly check orientation since older 
-                # GeoJSONs might not enforce this. 
+                # although the latest GeoJSON spec states that exterior rings should have
+                # counter-clockwise orientation, we explicitly check orientation since older
+                # GeoJSONs might not enforce this.
                 if i == 0 and not is_cw(ext_or_hole):
                     # flip exterior direction
                     ext_or_hole = rewind(ext_or_hole)
@@ -659,9 +659,9 @@ still included but were encoded as GeoJSON exterior rings instead of holes.'
             index = 0
             for polygon in geoj["coordinates"]:
                 for i,ext_or_hole in enumerate(polygon):
-                    # although the latest GeoJSON spec states that exterior rings should have 
-                    # counter-clockwise orientation, we explicitly check orientation since older 
-                    # GeoJSONs might not enforce this. 
+                    # although the latest GeoJSON spec states that exterior rings should have
+                    # counter-clockwise orientation, we explicitly check orientation since older
+                    # GeoJSONs might not enforce this.
                     if i == 0 and not is_cw(ext_or_hole):
                         # flip exterior direction
                         ext_or_hole = rewind(ext_or_hole)
@@ -726,7 +726,7 @@ class _Record(list):
         :param item: The field name, used as attribute
         :return: Value of the field
         :raises: AttributeError, if item is not a field of the shapefile
-                and IndexError, if the field exists but the field's 
+                and IndexError, if the field exists but the field's
                 corresponding value in the Record does not exist
         """
         try:
@@ -823,8 +823,8 @@ class _Record(list):
         """
         default = list(dir(type(self))) # default list methods and attributes of this class
         fnames = list(self.__field_positions.keys()) # plus field names (random order if Python version < 3.6)
-        return default + fnames 
-        
+        return default + fnames
+
 class ShapeRecord(object):
     """A ShapeRecord object containing a shape along with its attributes.
     Provides the GeoJSON __geo_interface__ to return a Feature dictionary."""
@@ -919,8 +919,8 @@ class Reader(object):
     but is not required to read the geometry from the .shp
     file. The "shapefile" argument in the constructor is the
     name of the file you want to open, and can be the path
-    to a shapefile on a local filesystem, inside a zipfile, 
-    or a url. 
+    to a shapefile on a local filesystem, inside a zipfile,
+    or a url.
 
     You can instantiate a Reader without specifying a shapefile
     and then specify one later with the load() method.
@@ -1049,7 +1049,7 @@ class Reader(object):
                     # Load and exit early
                     self.load(path)
                     return
-                    
+
         # Otherwise, load from separate shp/shx/dbf args (must be path or file-like)
         if "shp" in kwargs.keys():
             if hasattr(kwargs["shp"], "read"):
@@ -1062,7 +1062,7 @@ class Reader(object):
             else:
                 (baseName, ext) = os.path.splitext(kwargs["shp"])
                 self.load_shp(baseName)
-            
+
             if "shx" in kwargs.keys():
                 if hasattr(kwargs["shx"], "read"):
                     self.shx = kwargs["shx"]
@@ -1074,7 +1074,7 @@ class Reader(object):
                 else:
                     (baseName, ext) = os.path.splitext(kwargs["shx"])
                     self.load_shx(baseName)
-                
+
         if "dbf" in kwargs.keys():
             if hasattr(kwargs["dbf"], "read"):
                 self.dbf = kwargs["dbf"]
@@ -1086,7 +1086,7 @@ class Reader(object):
             else:
                 (baseName, ext) = os.path.splitext(kwargs["dbf"])
                 self.load_dbf(baseName)
-            
+
         # Load the files
         if self.shp or self.dbf:
             self.load()
@@ -1122,9 +1122,9 @@ class Reader(object):
             # Preferably use dbf record count
             if self.numRecords is None:
                 self.__dbfHeader()
-                
+
             return self.numRecords
-        
+
         elif self.shp:
             # Otherwise use shape count
             if self.shx:
@@ -1132,7 +1132,7 @@ class Reader(object):
                     self.__shxHeader()
 
                 return self.numShapes
-            
+
             else:
                 # Index file not available, iterate all shapes to get total count
                 if self.numShapes is None:
@@ -1158,12 +1158,12 @@ class Reader(object):
                     self._offsets = offsets
                     # Return to previous file position
                     shp.seek(checkpoint)
-                    
+
                 return self.numShapes
-            
+
         else:
             # No file loaded yet, treat as 'empty' shapefile
-            return 0 
+            return 0
 
     def __iter__(self):
         """Iterates through the shapes/records in the shapefile."""
@@ -1385,7 +1385,7 @@ class Reader(object):
                 record.m = [None]
         # Seek to the end of this record as defined by the record header because
         # the shapefile spec doesn't require the actual content to meet the header
-        # definition.  Probably allowed for lazy feature deletion. 
+        # definition.  Probably allowed for lazy feature deletion.
         f.seek(next)
         return record
 
@@ -1427,8 +1427,8 @@ class Reader(object):
     def shape(self, i=0, bbox=None):
         """Returns a shape object for a shape in the geometry
         record file.
-        If the 'bbox' arg is given (list or tuple of xmin,ymin,xmax,ymax), 
-        returns None if the shape is not within that region. 
+        If the 'bbox' arg is given (list or tuple of xmin,ymin,xmax,ymax),
+        returns None if the shape is not within that region.
         """
         shp = self.__getFileObj(self.shp)
         i = self.__restrictIndex(i)
@@ -1464,7 +1464,7 @@ class Reader(object):
     def shapes(self, bbox=None):
         """Returns all shapes in a shapefile.
         To only read shapes within a given spatial region, specify the 'bbox'
-        arg as a list or tuple of xmin,ymin,xmax,ymax. 
+        arg as a list or tuple of xmin,ymin,xmax,ymax.
         """
         shapes = Shapes()
         shapes.extend(self.iterShapes(bbox=bbox))
@@ -1474,7 +1474,7 @@ class Reader(object):
         """Returns a generator of shapes in a shapefile. Useful
         for handling large shapefiles.
         To only read shapes within a given spatial region, specify the 'bbox'
-        arg as a list or tuple of xmin,ymin,xmax,ymax. 
+        arg as a list or tuple of xmin,ymin,xmax,ymax.
         """
         shp = self.__getFileObj(self.shp)
         # Found shapefiles which report incorrect
@@ -1488,7 +1488,7 @@ class Reader(object):
         if self.numShapes:
             # Iterate exactly the number of shapes from shx header
             for i in xrange(self.numShapes):
-                # MAYBE: check if more left of file or exit early? 
+                # MAYBE: check if more left of file or exit early?
                 shape = self.__shape(oid=i, bbox=bbox)
                 if shape:
                     yield shape
@@ -1509,7 +1509,7 @@ class Reader(object):
             # Entire shp file consumed
             # Update the number of shapes and list of offsets
             assert i == len(offsets)
-            self.numShapes = i 
+            self.numShapes = i
             self._offsets = offsets
 
     def __dbfHeader(self):
@@ -1539,7 +1539,7 @@ class Reader(object):
         terminator = dbf.read(1)
         if terminator != b"\r":
             raise ShapefileException("Shapefile dbf header lacks expected terminator. (likely corrupt?)")
-        
+
         # insert deletion field at start
         self.fields.insert(0, ('DeletionFlag', 'C', 1, 0))
 
@@ -1555,9 +1555,9 @@ class Reader(object):
         self.__fullRecLookup = recLookup
 
     def __recordFmt(self, fields=None):
-        """Calculates the format and size of a .dbf record. Optional 'fields' arg 
+        """Calculates the format and size of a .dbf record. Optional 'fields' arg
         specifies which fieldnames to unpack and which to ignore. Note that this
-        always includes the DeletionFlag at index 0, regardless of the 'fields' arg. 
+        always includes the DeletionFlag at index 0, regardless of the 'fields' arg.
         """
         if self.numRecords is None:
             self.__dbfHeader()
@@ -1565,7 +1565,7 @@ class Reader(object):
                         for fieldinfo in self.fields]
         if fields is not None:
             # only unpack specified fields, ignore others using padbytes (x)
-            structcodes = [code if fieldinfo[0] in fields 
+            structcodes = [code if fieldinfo[0] in fields
                             or fieldinfo[0] == 'DeletionFlag' # always unpack delflag
                             else '%dx' % fieldinfo[2]
                             for fieldinfo,code in zip(self.fields, structcodes)]
@@ -1580,10 +1580,10 @@ class Reader(object):
 
     def __recordFields(self, fields=None):
         """Returns the necessary info required to unpack a record's fields,
-        restricted to a subset of fieldnames 'fields' if specified. 
-        Returns a list of field info tuples, a name-index lookup dict, 
+        restricted to a subset of fieldnames 'fields' if specified.
+        Returns a list of field info tuples, a name-index lookup dict,
         and a Struct instance for unpacking these fields. Note that DeletionFlag
-        is not a valid field. 
+        is not a valid field.
         """
         if fields is not None:
             # restrict info to the specified fields
@@ -1613,13 +1613,13 @@ class Reader(object):
 
     def __record(self, fieldTuples, recLookup, recStruct, oid=None):
         """Reads and returns a dbf record row as a list of values. Requires specifying
-        a list of field info tuples 'fieldTuples', a record name-index dict 'recLookup', 
-        and a Struct instance 'recStruct' for unpacking these fields. 
+        a list of field info tuples 'fieldTuples', a record name-index dict 'recLookup',
+        and a Struct instance 'recStruct' for unpacking these fields.
         """
         f = self.__getFileObj(self.dbf)
 
         recordContents = recStruct.unpack(f.read(recStruct.size))
-        
+
         # deletion flag field is always unpacked as first value (see __recordFmt)
         if recordContents[0] != b' ':
             # deleted record
@@ -1637,7 +1637,7 @@ class Reader(object):
         record = []
         for (name, typ, size, deci),value in zip(fieldTuples, recordContents):
             if typ in ("N","F"):
-                # numeric or float: number stored as a string, right justified, and padded with blanks to the width of the field. 
+                # numeric or float: number stored as a string, right justified, and padded with blanks to the width of the field.
                 value = value.split(b'\0')[0]
                 value = value.replace(b'*', b'')  # QGIS NULL is all '*' chars
                 if value == b'':
@@ -1654,7 +1654,7 @@ class Reader(object):
                         # first try to force directly to int.
                         # forcing a large int to float and back to int
                         # will lose information and result in wrong nr.
-                        value = int(value) 
+                        value = int(value)
                     except ValueError:
                         # forcing directly to int failed, so was probably a float.
                         try:
@@ -1698,7 +1698,7 @@ class Reader(object):
     def record(self, i=0, fields=None):
         """Returns a specific dbf record based on the supplied index.
         To only read some of the fields, specify the 'fields' arg as a
-        list of one or more fieldnames. 
+        list of one or more fieldnames.
         """
         f = self.__getFileObj(self.dbf)
         if self.numRecords is None:
@@ -1711,7 +1711,7 @@ class Reader(object):
         return self.__record(oid=i, fieldTuples=fieldTuples, recLookup=recLookup, recStruct=recStruct)
 
     def records(self, fields=None):
-        """Returns all records in a dbf file. 
+        """Returns all records in a dbf file.
         To only read some of the fields, specify the 'fields' arg as a
         list of one or more fieldnames.
         """
@@ -1745,11 +1745,11 @@ class Reader(object):
 
     def shapeRecord(self, i=0, fields=None, bbox=None):
         """Returns a combination geometry and attribute record for the
-        supplied record index. 
+        supplied record index.
         To only read some of the fields, specify the 'fields' arg as a
-        list of one or more fieldnames. 
-        If the 'bbox' arg is given (list or tuple of xmin,ymin,xmax,ymax), 
-        returns None if the shape is not within that region. 
+        list of one or more fieldnames.
+        If the 'bbox' arg is given (list or tuple of xmin,ymin,xmax,ymax),
+        returns None if the shape is not within that region.
         """
         i = self.__restrictIndex(i)
         shape = self.shape(i, bbox=bbox)
@@ -1761,9 +1761,9 @@ class Reader(object):
         """Returns a list of combination geometry/attribute records for
         all records in a shapefile.
         To only read some of the fields, specify the 'fields' arg as a
-        list of one or more fieldnames. 
+        list of one or more fieldnames.
         To only read entries within a given spatial region, specify the 'bbox'
-        arg as a list or tuple of xmin,ymin,xmax,ymax. 
+        arg as a list or tuple of xmin,ymin,xmax,ymax.
         """
         return ShapeRecords(self.iterShapeRecords(fields=fields, bbox=bbox))
 
@@ -1771,9 +1771,9 @@ class Reader(object):
         """Returns a generator of combination geometry/attribute records for
         all records in a shapefile.
         To only read some of the fields, specify the 'fields' arg as a
-        list of one or more fieldnames. 
+        list of one or more fieldnames.
         To only read entries within a given spatial region, specify the 'bbox'
-        arg as a list or tuple of xmin,ymin,xmax,ymax. 
+        arg as a list or tuple of xmin,ymin,xmax,ymax.
         """
         if bbox is None:
             # iterate through all shapes and records
@@ -1782,13 +1782,13 @@ class Reader(object):
         else:
             # only iterate where shape.bbox overlaps with the given bbox
             # TODO: internal __record method should be faster but would have to
-            # make sure to seek to correct file location... 
+            # make sure to seek to correct file location...
 
             #fieldTuples,recLookup,recStruct = self.__recordFields(fields)
             for shape in self.iterShapes(bbox=bbox):
                 if shape:
                     #record = self.__record(oid=i, fieldTuples=fieldTuples, recLookup=recLookup, recStruct=recStruct)
-                    record = self.record(i=shape.oid, fields=fields) 
+                    record = self.record(i=shape.oid, fields=fields)
                     yield ShapeRecord(shape=shape, record=record)
 
 
@@ -1819,8 +1819,8 @@ class Writer(object):
         else:
             raise Exception('Either the target filepath, or any of shp, shx, or dbf must be set to create a shapefile.')
         # Initiate with empty headers, to be finalized upon closing
-        if self.shp: self.shp.write(b'9'*100) 
-        if self.shx: self.shx.write(b'9'*100) 
+        if self.shp: self.shp.write(b'9'*100)
+        if self.shx: self.shx.write(b'9'*100)
         # Geometry record offsets and lengths for writing shx file.
         self.recNum = 0
         self.shpNum = 0
@@ -1828,16 +1828,16 @@ class Writer(object):
         self._zbox = None
         self._mbox = None
         # Use deletion flags in dbf? Default is false (0). Note: Currently has no effect, records should NOT contain deletion flags.
-        self.deletionFlag = 0 
+        self.deletionFlag = 0
         # Encoding
         self.encoding = kwargs.pop('encoding', 'utf-8')
         self.encodingErrors = kwargs.pop('encodingErrors', 'strict')
 
     def __len__(self):
-        """Returns the current number of features written to the shapefile. 
+        """Returns the current number of features written to the shapefile.
         If shapes and records are unbalanced, the length is considered the highest
         of the two."""
-        return max(self.recNum, self.shpNum) 
+        return max(self.recNum, self.shpNum)
 
     def __enter__(self):
         """
@@ -1862,7 +1862,7 @@ class Writer(object):
         shp_open = self.shp and not (hasattr(self.shp, 'closed') and self.shp.closed)
         shx_open = self.shx and not (hasattr(self.shx, 'closed') and self.shx.closed)
         dbf_open = self.dbf and not (hasattr(self.dbf, 'closed') and self.dbf.closed)
-            
+
         # Balance if already not balanced
         if self.shp and shp_open and self.dbf and dbf_open:
             if self.autoBalance:
@@ -1934,8 +1934,8 @@ class Writer(object):
             y.extend(py)
         else:
             # this should not happen.
-            # any shape that is not null should have at least one point, and only those should be sent here. 
-            # could also mean that earlier code failed to add points to a non-null shape. 
+            # any shape that is not null should have at least one point, and only those should be sent here.
+            # could also mean that earlier code failed to add points to a non-null shape.
             raise Exception("Cannot create bbox. Expected a valid shape with at least one point. Got a shape of type '%s' and 0 points." % s.shapeType)
         bbox = [min(x), min(y), max(x), max(y)]
         # update global
@@ -2035,7 +2035,7 @@ class Writer(object):
                     # In such cases of empty shapefiles, ESRI spec says the bbox values are 'unspecified'.
                     # Not sure what that means, so for now just setting to 0s, which is the same behavior as in previous versions.
                     # This would also make sense since the Z and M bounds are similarly set to 0 for non-Z/M type shapefiles.
-                    bbox = [0,0,0,0] 
+                    bbox = [0,0,0,0]
                 f.write(pack("<4d", *bbox))
             except error:
                 raise ShapefileException("Failed to write shapefile bounding box. Floats required.")
@@ -2179,7 +2179,7 @@ class Writer(object):
                     f.write(pack("<%sd" % len(s.z), *s.z))
                 else:
                     # if z values are stored as 3rd dimension
-                    [f.write(pack("<d", p[2] if len(p) > 2 else 0)) for p in s.points]  
+                    [f.write(pack("<d", p[2] if len(p) > 2 else 0)) for p in s.points]
             except error:
                 raise ShapefileException("Failed to write elevation values for record %s. Expected floats." % self.shpNum)
         # Write m extremes and values
@@ -2191,7 +2191,7 @@ class Writer(object):
             except error:
                 raise ShapefileException("Failed to write measure extremes for record %s. Expected floats" % self.shpNum)
             try:
-                if hasattr(s,"m"): 
+                if hasattr(s,"m"):
                     # if m values are stored in attribute
                     f.write(pack("<%sd" % len(s.m), *[m if m is not None else NODATA for m in s.m]))
                 else:
@@ -2239,7 +2239,7 @@ class Writer(object):
                 # if m values are stored in attribute
                 try:
                     if not s.m or s.m[0] is None:
-                        s.m = (NODATA,) 
+                        s.m = (NODATA,)
                     f.write(pack("<1d", s.m[0]))
                 except error:
                     raise ShapefileException("Failed to write measure value for record %s. Expected floats." % self.shpNum)
@@ -2284,7 +2284,7 @@ class Writer(object):
         # Balance if already not balanced
         if self.autoBalance and self.recNum > self.shpNum:
             self.balance()
-            
+
         fieldCount = sum((1 for field in self.fields if field[0] != 'DeletionFlag'))
         if recordList:
             record = list(recordList)
@@ -2322,7 +2322,7 @@ class Writer(object):
         self.recNum += 1
         fields = (field for field in self.fields if field[0] != 'DeletionFlag') # ignore deletionflag field in case it was specified
         for (fieldName, fieldType, size, deci), value in zip(fields, record):
-            # write 
+            # write
             fieldType = fieldType.upper()
             size = int(size)
             if fieldType in ("N","F"):
@@ -2335,7 +2335,7 @@ class Writer(object):
                         # first try to force directly to int.
                         # forcing a large int to float and back to int
                         # will lose information and result in wrong nr.
-                        value = int(value) 
+                        value = int(value)
                     except ValueError:
                         # forcing directly to int failed, so was probably a float.
                         value = int(float(value))
@@ -2415,7 +2415,7 @@ class Writer(object):
         pointShape = Shape(shapeType)
         pointShape.points.append([x, y, z, m])
         self.shape(pointShape)
-        
+
 
     def multipoint(self, points):
         """Creates a MULTIPOINT shape.
@@ -2600,8 +2600,8 @@ class Writer(object):
 ##        be written exclusively using saveShp, saveShx, and saveDbf respectively.
 ##        If target is specified but not shp, shx, or dbf then the target path and
 ##        file name are used.  If no options or specified, a unique base file name
-##        is generated to save the files and the base file name is returned as a 
-##        string. 
+##        is generated to save the files and the base file name is returned as a
+##        string.
 ##        """
 ##        # Balance if already not balanced
 ##        if shp and dbf:
@@ -2624,7 +2624,7 @@ class Writer(object):
 ##            if not target:
 ##                temp = tempfile.NamedTemporaryFile(prefix="shapefile_",dir=os.getcwd())
 ##                target = temp.name
-##                generated = True         
+##                generated = True
 ##            self.saveShp(target)
 ##            self.shp.close()
 ##            self.saveShx(target)
@@ -2670,11 +2670,11 @@ def test(**kwargs):
             runner.summarize(verbosity)
 
     return failure_count
-    
+
 if __name__ == "__main__":
     """
     Doctests are contained in the file 'README.md', and are tested using the built-in
-    testing libraries. 
+    testing libraries.
     """
     failure_count = test()
     sys.exit(failure_count)

--- a/test_shapefile.py
+++ b/test_shapefile.py
@@ -293,7 +293,7 @@ def test_reader_zip():
             pass
         assert len(sf) > 0
     assert sf.shp.closed == sf.shx.closed == sf.dbf.closed == True
-    
+
     # test require specific path when reading multi-shapefile zipfile
     with pytest.raises(shapefile.ShapefileException):
         with shapefile.Reader("shapefiles/blockgroups_multishapefile.zip") as sf:
@@ -584,7 +584,7 @@ def test_reader_shapefile_delayed_load():
     with shapefile.Reader() as sf:
         # assert that data request raises exception, since no file has been provided yet
         with pytest.raises(shapefile.ShapefileException):
-            sf.shape(0) 
+            sf.shape(0)
         # assert that works after loading file manually
         sf.load("shapefiles/blockgroups")
         assert len(sf) == 663
@@ -603,7 +603,7 @@ def test_records_match_shapes():
 
 def test_record_attributes(fields=None):
     """
-    Assert that record retrieves all relevant values and can 
+    Assert that record retrieves all relevant values and can
     be accessed as attributes and dictionary items.
     """
     # note
@@ -634,7 +634,7 @@ def test_record_attributes(fields=None):
 
 def test_record_subfields():
     """
-    Assert that reader correctly retrieves only a subset 
+    Assert that reader correctly retrieves only a subset
     of fields when specified.
     """
     fields = ["AREA","POP1990","MALES","FEMALES","MOBILEHOME"]
@@ -643,9 +643,9 @@ def test_record_subfields():
 
 def test_record_subfields_unordered():
     """
-    Assert that reader correctly retrieves only a subset 
-    of fields when specified, given in random order but 
-    retrieved in the order of the shapefile fields. 
+    Assert that reader correctly retrieves only a subset
+    of fields when specified, given in random order but
+    retrieved in the order of the shapefile fields.
     """
     fields = sorted(["AREA","POP1990","MALES","FEMALES","MOBILEHOME"])
     test_record_attributes(fields=fields)
@@ -663,7 +663,7 @@ def test_record_subfields_delflag_notvalid():
 def test_record_subfields_duplicates():
     """
     Assert that reader correctly retrieves only a subset
-    of fields when specified, handling duplicate input fields. 
+    of fields when specified, handling duplicate input fields.
     """
     fields = ["AREA","AREA","AREA","MALES","MALES","MOBILEHOME"]
     test_record_attributes(fields=fields)
@@ -676,7 +676,7 @@ def test_record_subfields_duplicates():
 def test_record_subfields_empty():
     """
     Assert that reader does not retrieve any fields when given
-    an empty list. 
+    an empty list.
     """
     fields = []
     test_record_attributes(fields=fields)
@@ -774,8 +774,8 @@ def test_shape_oid_no_shx():
 
 def test_reader_offsets():
     """
-    Assert that reader will not read the shx offsets unless necessary, 
-    i.e. requesting a shape index. 
+    Assert that reader will not read the shx offsets unless necessary,
+    i.e. requesting a shape index.
     """
     basename = "shapefiles/blockgroups"
     with shapefile.Reader(basename) as sf:
@@ -788,8 +788,8 @@ def test_reader_offsets():
 
 def test_reader_offsets_no_shx():
     """
-    Assert that reading a shapefile without a shx file will not build 
-    the offsets unless necessary, i.e. reading all the shapes. 
+    Assert that reading a shapefile without a shx file will not build
+    the offsets unless necessary, i.e. reading all the shapes.
     """
     basename = "shapefiles/blockgroups"
     shp = open(basename + ".shp", 'rb')
@@ -810,7 +810,7 @@ def test_reader_offsets_no_shx():
 def test_reader_numshapes():
     """
     Assert that reader reads the numShapes attribute from the
-    shx file header during loading. 
+    shx file header during loading.
     """
     basename = "shapefiles/blockgroups"
     with shapefile.Reader(basename) as sf:
@@ -839,8 +839,8 @@ def test_reader_numshapes_no_shx():
 
 def test_reader_len():
     """
-    Assert that calling len() on reader is equal to length of 
-    all shapes and records. 
+    Assert that calling len() on reader is equal to length of
+    all shapes and records.
     """
     basename = "shapefiles/blockgroups"
     with shapefile.Reader(basename) as sf:
@@ -850,7 +850,7 @@ def test_reader_len():
 def test_reader_len_not_loaded():
     """
     Assert that calling len() on reader that hasn't loaded a shapefile
-    yet is equal to 0. 
+    yet is equal to 0.
     """
     with shapefile.Reader() as sf:
         assert len(sf) == 0
@@ -859,7 +859,7 @@ def test_reader_len_not_loaded():
 def test_reader_len_dbf_only():
     """
     Assert that calling len() on reader when reading a dbf file only,
-    is equal to length of all records. 
+    is equal to length of all records.
     """
     basename = "shapefiles/blockgroups"
     dbf = open(basename + ".dbf", 'rb')
@@ -870,7 +870,7 @@ def test_reader_len_dbf_only():
 def test_reader_len_no_dbf():
     """
     Assert that calling len() on reader when dbf file is missing,
-    is equal to length of all shapes. 
+    is equal to length of all shapes.
     """
     basename = "shapefiles/blockgroups"
     shp = open(basename + ".shp", 'rb')
@@ -882,7 +882,7 @@ def test_reader_len_no_dbf():
 def test_reader_len_no_dbf_shx():
     """
     Assert that calling len() on reader when dbf and shx file is missing,
-    is equal to length of all shapes. 
+    is equal to length of all shapes.
     """
     basename = "shapefiles/blockgroups"
     shp = open(basename + ".shp", 'rb')
@@ -893,7 +893,7 @@ def test_reader_len_no_dbf_shx():
 def test_reader_corrupt_files():
     """
     Assert that reader is able to handle corrupt files by
-    strictly going off the header information. 
+    strictly going off the header information.
     """
     basename = "shapefiles/test/corrupt_too_long"
 
@@ -931,7 +931,7 @@ def test_reader_corrupt_files():
 def test_bboxfilter_shape():
     """
     Assert that applying the bbox filter to shape() correctly ignores the shape
-    if it falls outside, and returns it if inside. 
+    if it falls outside, and returns it if inside.
     """
     inside = [-122.4, 37.8, -122.35, 37.82]
     outside = list(inside)
@@ -945,7 +945,7 @@ def test_bboxfilter_shape():
 def test_bboxfilter_shapes():
     """
     Assert that applying the bbox filter to shapes() correctly ignores shapes
-    that fall outside, and returns those that fall inside. 
+    that fall outside, and returns those that fall inside.
     """
     bbox = [-122.4, 37.8, -122.35, 37.82]
     with shapefile.Reader("shapefiles/blockgroups") as sf:
@@ -967,7 +967,7 @@ def test_bboxfilter_shapes():
 def test_bboxfilter_shapes_outside():
     """
     Assert that applying the bbox filter to shapes() correctly returns
-    no shapes when the bbox is outside the entire shapefile. 
+    no shapes when the bbox is outside the entire shapefile.
     """
     bbox = [-180, 89, -179, 90]
     with shapefile.Reader("shapefiles/blockgroups") as sf:
@@ -978,7 +978,7 @@ def test_bboxfilter_shapes_outside():
 def test_bboxfilter_itershapes():
     """
     Assert that applying the bbox filter to iterShapes() correctly ignores shapes
-    that fall outside, and returns those that fall inside. 
+    that fall outside, and returns those that fall inside.
     """
     bbox = [-122.4, 37.8, -122.35, 37.82]
     with shapefile.Reader("shapefiles/blockgroups") as sf:
@@ -1000,7 +1000,7 @@ def test_bboxfilter_itershapes():
 def test_bboxfilter_shaperecord():
     """
     Assert that applying the bbox filter to shapeRecord() correctly ignores the shape
-    if it falls outside, and returns it if inside. 
+    if it falls outside, and returns it if inside.
     """
     inside = [-122.4, 37.8, -122.35, 37.82]
     outside = list(inside)
@@ -1018,7 +1018,7 @@ def test_bboxfilter_shaperecord():
 def test_bboxfilter_shaperecords():
     """
     Assert that applying the bbox filter to shapeRecords() correctly ignores shapes
-    that fall outside, and returns those that fall inside. 
+    that fall outside, and returns those that fall inside.
     """
     bbox = [-122.4, 37.8, -122.35, 37.82]
     with shapefile.Reader("shapefiles/blockgroups") as sf:
@@ -1046,7 +1046,7 @@ def test_bboxfilter_shaperecords():
 def test_bboxfilter_itershaperecords():
     """
     Assert that applying the bbox filter to iterShapeRecords() correctly ignores shapes
-    that fall outside, and returns those that fall inside. 
+    that fall outside, and returns those that fall inside.
     """
     bbox = [-122.4, 37.8, -122.35, 37.82]
     with shapefile.Reader("shapefiles/blockgroups") as sf:
@@ -1153,7 +1153,7 @@ def test_write_shp_only(tmpdir):
 
     # assert test.shp exists
     assert os.path.exists(filename+'.shp')
-    
+
     # test that can read shapes
     with shapefile.Reader(shp=filename+'.shp') as reader:
         assert reader.shp and not reader.shx and not reader.dbf
@@ -1220,7 +1220,7 @@ def test_write_shp_dbf_only(tmpdir):
 
     # assert test.dbf exists
     assert os.path.exists(filename+'.dbf')
-    
+
     # test that can read records and shapes
     with shapefile.Reader(shp=filename+'.shp', dbf=filename+'.dbf') as reader:
         assert reader.shp and not reader.shx and reader.dbf
@@ -1308,7 +1308,7 @@ def test_write_filelike(tmpdir):
         writer.field('field1', 'C') # required to create a valid dbf file
         writer.record('value')
         writer.null()
-        
+
     # test that filelike objects were written correctly
     with shapefile.Reader(shp=shp, shx=shx, dbf=dbf) as reader:
         assert len(reader) == 1
@@ -1431,17 +1431,17 @@ def test_write_shapefile_extension_ignored(tmpdir):
 def test_write_record(tmpdir):
     """
     Test that .record() correctly writes a record using either a list of *args
-    or a dict of **kwargs. 
+    or a dict of **kwargs.
     """
     filename = tmpdir.join("test.shp").strpath
     with shapefile.Writer(filename) as writer:
         writer.autoBalance = True
 
-        writer.field('one', 'C') 
-        writer.field('two', 'C') 
-        writer.field('three', 'C') 
-        writer.field('four', 'C') 
-        
+        writer.field('one', 'C')
+        writer.field('two', 'C')
+        writer.field('three', 'C')
+        writer.field('four', 'C')
+
         values = ['one','two','three','four']
         writer.record(*values)
         writer.record(*values)
@@ -1458,17 +1458,17 @@ def test_write_record(tmpdir):
 def test_write_partial_record(tmpdir):
     """
     Test that .record() correctly writes a partial record (given only some of the values)
-    using either a list of *args or a dict of **kwargs. Should fill in the gaps. 
+    using either a list of *args or a dict of **kwargs. Should fill in the gaps.
     """
     filename = tmpdir.join("test.shp").strpath
     with shapefile.Writer(filename) as writer:
         writer.autoBalance = True
-        
-        writer.field('one', 'C') 
-        writer.field('two', 'C') 
-        writer.field('three', 'C') 
-        writer.field('four', 'C') 
-        
+
+        writer.field('one', 'C')
+        writer.field('two', 'C')
+        writer.field('three', 'C')
+        writer.field('four', 'C')
+
         values = ['one','two']
         writer.record(*values)
         writer.record(*values)
@@ -1519,7 +1519,7 @@ shape_types = [k for k in shapefile.SHAPETYPE_LOOKUP.keys() if k != 31] # exclud
 @pytest.mark.parametrize("shape_type", shape_types)
 def test_write_empty_shapefile(tmpdir, shape_type):
     """
-    Assert that can write an empty shapefile, for all different shape types. 
+    Assert that can write an empty shapefile, for all different shape types.
     """
     filename = tmpdir.join("test").strpath
     with shapefile.Writer(filename, shapeType=shape_type) as w:


### PR DESCRIPTION
```shell
find . -type f | egrep -v '[.]git/|shapefiles/' | xargs perl -pi -e 's/\s+\n/\n/g'
```