### PR TITLE
Refine git line endings behaviour

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 * text eol=lf
-shapefiles binary
+shapefiles/**/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-* eol=lf
+* text eol=lf
+shapefiles binary


### PR DESCRIPTION
Don't auto convert 'line endings' of shapefiles and zip archives.