### PR TITLE
Add method `iterRecords_range`

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -1809,7 +1809,7 @@ class Reader(object):
                 records.append(r)
         return records
 
-    def iterRecords(self, fields=None, my_range=None):
+    def iterRecords(self, fields=None):
         """Returns a generator of records in a dbf file.
         Useful for large shapefiles or dbf files.
         To only read some of the fields, specify the 'fields' arg as a
@@ -1820,9 +1820,7 @@ class Reader(object):
         f = self.__getFileObj(self.dbf)
         f.seek(self.__dbfHdrLength)
         fieldTuples, recLookup, recStruct = self.__recordFields(fields)
-        if my_range is None:
-            my_range = xrange(self.numRecords)
-        for i in my_range:
+        for i in xrange(self.numRecords):
             r = self.__record(
                 oid=i, fieldTuples=fieldTuples, recLookup=recLookup, recStruct=recStruct
             )

--- a/shapefile.py
+++ b/shapefile.py
@@ -1809,7 +1809,7 @@ class Reader(object):
                 records.append(r)
         return records
 
-    def iterRecords(self, fields=None):
+    def iterRecords(self, fields=None, my_range=None):
         """Returns a generator of records in a dbf file.
         Useful for large shapefiles or dbf files.
         To only read some of the fields, specify the 'fields' arg as a
@@ -1820,7 +1820,9 @@ class Reader(object):
         f = self.__getFileObj(self.dbf)
         f.seek(self.__dbfHdrLength)
         fieldTuples, recLookup, recStruct = self.__recordFields(fields)
-        for i in xrange(self.numRecords):
+        if my_range is None:
+            my_range = xrange(self.numRecords)
+        for i in my_range:
             r = self.__record(
                 oid=i, fieldTuples=fieldTuples, recLookup=recLookup, recStruct=recStruct
             )

--- a/shapefile.py
+++ b/shapefile.py
@@ -1827,6 +1827,32 @@ class Reader(object):
             if r:
                 yield r
 
+    def iterRecords_range(self, start, stop, fields=None):
+        """Returns a generator of records in a dbf file, for a range
+        of oid.  Useful for large shapefiles or dbf files.  To only
+        read some of the fields, specify the 'fields' arg as a list of
+        one or more fieldnames.
+
+        """
+        if self.numRecords is None:
+            self.__dbfHeader()
+        f = self.__getFileObj(self.dbf)
+        start = self.__restrictIndex(start)
+        if abs(stop) > self.numRecords:
+            raise IndexError("Record index out of range.")
+        if stop < 0:
+            stop = range(self.numRecords)[stop]
+        recSize = self.__recordLength
+        f.seek(0)
+        f.seek(self.__dbfHdrLength + (start * recSize))
+        fieldTuples, recLookup, recStruct = self.__recordFields(fields)
+        for i in xrange(start, stop):
+            r = self.__record(
+                oid=i, fieldTuples=fieldTuples, recLookup=recLookup, recStruct=recStruct
+            )
+            if r:
+                yield r
+
     def shapeRecord(self, i=0, fields=None, bbox=None):
         """Returns a combination geometry and attribute record for the
         supplied record index.


### PR DESCRIPTION
I have tested this by reading about one million record:
```
#!/usr/bin/env python3

import time

import shapefile

r = shapefile.Reader("extremum")
t0 = time.perf_counter()

for i in range(10, 1000000):
    x = r.record(i)

t1 = time.perf_counter()
print(t1 - t0)
t0 = time.perf_counter()

for x in r.iterRecords_range(10, 1000000):
    pass

t1 = time.perf_counter()
print(t1 - t0)
```
I get:
```
$ test_iterRecords_range.py 
21.27043527108617
7.878919951850548
```
So  `iterRecords_range` is somewhat faster.
