### PR TITLE
Make flakey network dependent tests optional

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,6 +4,11 @@ name:
 description:
   Run pytest, and run the doctest runner (shapefile.py as a script).
 
+inputs:
+  extra_args:
+    type: string
+    default: '-m "not network"'
+
 runs:
   using: "composite"
   steps:
@@ -13,7 +18,7 @@ runs:
 
     - name: Doctests
       shell: bash
-      run: python shapefile.py
+      run: python shapefile.py ${{ inputs.extra_args }}
 
     - name: Install test dependencies.
       shell: bash
@@ -24,7 +29,7 @@ runs:
     - name: Pytest
       shell: bash
       run: |
-        pytest
+        pytest ${{ inputs.extra_args }}
 
     - name: Show versions for logs.
       shell: bash


### PR DESCRIPTION
This reverts commit 2dc17a78c4eb90196b36169e897ec36f55a6223e.

Run on this branch

Instead of plain pytest, run pytest -m "not network"

Filter out pytest tests and doctests requiring internet downloads

Run Ruff format

Make skipping network tests optional