### PR TITLE
Use localhost instead of remote server for network marked tests.

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,38 +1,119 @@
 name:
-  Test
+  Run Doctests and Pytest
 
 description:
   Run pytest, and run the doctest runner (shapefile.py as a script).
 
 inputs:
   extra_args:
-    type: string
+    description: Extra command line args for Pytest and python shapefile.py
     default: '-m "not network"'
+    required: false
+  replace_remote_urls_with_localhost:
+    description: yes or no.  Test loading shapefiles from a url, without overloading an external server from 30 parallel workflows.
+    default: 'no'
+    required: false
+  pyshp_repo_directory:
+    description: Path to where the PyShp repo was checked out to (to keep separate from Shapefiles & artefacts repo).
+    required: false
+    default: '.'
+  python-version:
+    description: Set to "2.7" to use caddy instead of python -m SimpleHTTPServer
+    required: true
+
+
 
 runs:
   using: "composite"
   steps:
-    # The Repo is required to already be checked out, e.g. by the calling workflow
+    # The PyShp repo is required to already be checked out into pyshp_repo_directory,
+    # e.g. by the calling workflow using:
+    # steps:
+    # - uses: actions/checkout@v4
+    #   with:
+    #     path: ./Pyshp
+    # and then calling this Action with:
+    # - name: Run tests
+    #   uses: ./Pyshp/.github/actions/test
+    #   with:
+    #     extra_args: ""
+    #     replace_remote_urls_with_localhost: 'yes'
+    #     pyshp_repo_directory: ./Pyshp
 
     # The Python to be tested with is required to already be setup, with "python" and "pip" on the system Path
 
+    - name: Checkout shapefiles and zip file artefacts repo
+      if: ${{ inputs.replace_remote_urls_with_localhost == 'yes' }}
+      uses: actions/checkout@v4
+      with:
+        repository: JamesParrott/PyShp_test_shapefile
+        path: ./PyShp_test_shapefile
+
+    - name: Serve shapefiles and zip file artefacts on localhost
+      if: ${{ inputs.replace_remote_urls_with_localhost == 'yes'  && inputs.python-version != '2.7'}}
+      shell: bash
+      working-directory: ./PyShp_test_shapefile
+      run: |
+        python -m http.server 8000 &
+        echo "HTTP_SERVER_PID=$!" >> $GITHUB_ENV
+        sleep 4  # give server time to start
+
+    - name: Download and unzip Caddy binary
+      if: ${{ inputs.replace_remote_urls_with_localhost == 'yes' && inputs.python-version == '2.7'}}
+      working-directory: .
+      shell: bash
+      run: |
+        curl -L https://github.com/caddyserver/caddy/releases/download/v2.10.0/caddy_2.10.0_linux_amd64.tar.gz --output caddy.tar.gz
+        tar -xzf caddy.tar.gz
+
+    - name: Serve shapefiles and zip file artefacts on localhost using Caddy
+      if: ${{ inputs.replace_remote_urls_with_localhost == 'yes' && inputs.python-version == '2.7'}}
+      shell: bash
+      working-directory: .
+      run: |
+        ./caddy file-server --root ./PyShp_test_shapefile --listen :8000 &
+        echo "HTTP_SERVER_PID=$!" >> $GITHUB_ENV
+        sleep 2  # give server time to start
+
     - name: Doctests
       shell: bash
+      working-directory: ${{ inputs.pyshp_repo_directory }}
+      env:
+        REPLACE_REMOTE_URLS_WITH_LOCALHOST: ${{ inputs.replace_remote_urls_with_localhost }}
       run: python shapefile.py ${{ inputs.extra_args }}
 
     - name: Install test dependencies.
       shell: bash
+      working-directory: ${{ inputs.pyshp_repo_directory }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.test.txt
 
     - name: Pytest
       shell: bash
+      working-directory: ${{ inputs.pyshp_repo_directory }}
+      env:
+        REPLACE_REMOTE_URLS_WITH_LOCALHOST: ${{ inputs.replace_remote_urls_with_localhost }}
       run: |
-        pytest ${{ inputs.extra_args }}
+        pytest  -rA --tb=short ${{ inputs.extra_args }}
 
     - name: Show versions for logs.
       shell: bash
       run: |
         python --version
         python -m pytest --version
+
+
+    # - name: Test http server
+    #   # (needs a full Github Actions runner or a Python non-slim Docker image,
+    #   # as the slim Debian images don't have curl or wget).
+    #   if: ${{ inputs.replace_remote_urls_with_localhost == 'yes' }}
+    #   shell: bash
+    #   run: curl http://localhost:8000/ne_110m_admin_0_tiny_countries.shp
+
+    - name: Stop http server
+      if: ${{ inputs.replace_remote_urls_with_localhost == 'yes' }}
+      shell: bash
+      run: |
+        echo Killing http server process ID: ${{ env.HTTP_SERVER_PID }}
+        kill ${{ env.HTTP_SERVER_PID }}

--- a/.github/workflows/run_tests_hooks_and_tools.yml
+++ b/.github/workflows/run_tests_hooks_and_tools.yml
@@ -5,7 +5,7 @@ name: Run pre-commit hooks and tests
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches: [ master, ]
   workflow_call:
   workflow_dispatch:
 
@@ -30,7 +30,7 @@ jobs:
       run: |
         pylint --disable=R,C test_shapefile.py
 
-  test_on_old_Pythons:
+  test_on_EOL_Pythons:
     strategy:
       fail-fast: false
       matrix:
@@ -44,16 +44,28 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: python:${{ matrix.python-version }}-slim
+      image: python:${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        path: ./Pyshp
 
-    - name: Run tests
-      uses: ./.github/actions/test
+    - name: Non-network tests
+      uses: ./Pyshp/.github/actions/test
+      with:
+        pyshp_repo_directory: ./Pyshp
+        python-version: ${{ matrix.python-version }}
 
+    - name: Network tests
+      uses: ./Pyshp/.github/actions/test
+      with:
+        extra_args: '-m network'
+        replace_remote_urls_with_localhost: 'yes'
+        pyshp_repo_directory: ./Pyshp
+        python-version: ${{ matrix.python-version }}
 
-  run_tests:
+  test_on_supported_Pythons:
     strategy:
       fail-fast: false
       matrix:
@@ -74,11 +86,24 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Run tests
-      uses: ./.github/actions/test
+    - uses: actions/checkout@v4
+      with:
+        path: ./Pyshp
+
+    - name: Non-network tests
+      uses: ./Pyshp/.github/actions/test
+      with:
+        pyshp_repo_directory: ./Pyshp
+        python-version: ${{ matrix.python-version }}
+
+    - name: Network tests
+      uses: ./Pyshp/.github/actions/test
+      with:
+        extra_args: '-m network'
+        replace_remote_urls_with_localhost: 'yes'
+        pyshp_repo_directory: ./Pyshp
+        python-version: ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.4
   hooks:
-    - id: check-yaml
-    - id: trailing-whitespace
+    - id: ruff-format
 - repo: https://github.com/pycqa/isort
   rev: 5.13.2
   hooks:
     - id: isort
       name: isort (python)
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.4
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
   hooks:
-    - id: ruff-format
+    - id: check-yaml
+    - id: trailing-whitespace

--- a/test_shapefile.py
+++ b/test_shapefile.py
@@ -487,16 +487,31 @@ def test_reader_url():
     """
     Assert that Reader can open shapefiles from a url.
     """
+
+    # Allow testing loading of shapefiles from a url on localhost (to avoid
+    # overloading external servers, and associated spurious test failures).
+    # A suitable repo of test files, and a localhost server setup is
+    # defined in ./.github/actions/test/actions.yml
+    if shapefile.REPLACE_REMOTE_URLS_WITH_LOCALHOST:
+
+        def Reader(url):
+            new_url = shapefile._replace_remote_url(url)
+            print("repr(new_url): %s" % repr(new_url))
+            return shapefile.Reader(new_url)
+    else:
+        print("Using plain Reader")
+        Reader = shapefile.Reader
+
     # test with extension
     url = "https://github.com/nvkelso/natural-earth-vector/blob/master/110m_cultural/ne_110m_admin_0_tiny_countries.shp?raw=true"
-    with shapefile.Reader(url) as sf:
+    with Reader(url) as sf:
         for __recShape in sf.iterShapeRecords():
             pass
     assert sf.shp.closed is sf.shx.closed is sf.dbf.closed is True
 
     # test without extension
     url = "https://github.com/nvkelso/natural-earth-vector/blob/master/110m_cultural/ne_110m_admin_0_tiny_countries?raw=true"
-    with shapefile.Reader(url) as sf:
+    with Reader(url) as sf:
         for __recShape in sf.iterShapeRecords():
             pass
         assert len(sf) > 0
@@ -505,12 +520,12 @@ def test_reader_url():
     # test no files found
     url = "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/README.md"
     with pytest.raises(shapefile.ShapefileException):
-        with shapefile.Reader(url) as sf:
+        with Reader(url) as sf:
             pass
 
     # test reading zipfile from url
     url = "https://github.com/JamesParrott/PyShp_test_shapefile/raw/main/gis_osm_natural_a_free_1.zip"
-    with shapefile.Reader(url) as sf:
+    with Reader(url) as sf:
         for __recShape in sf.iterShapeRecords():
             pass
         assert len(sf) > 0


### PR DESCRIPTION
Run on this branch

Run Network tests in container jobs

Remove type field from Action input

Add description and required fields to Action input.

Add option to Clone repo of copies of files to serve locally in mock remote url tests

Specify shell in action job step

Use actions/checkout instead of git (unavailable in Python slim docker images)

Checkout artefacts repo to ..

Add pyshp_repo_directory input

Serve artefacts on localhost:8000

Specify shell: bash in Github action

Don't curl from localhost - not available in Python slim images (neither is wget)

TRy requesting on localhost in Python non-slim images

Correct path to custom test file

Test local server

Sleep for twice as long after  starting simple Python server

Don't output PyTest version

Swap out remote URLs with stripped path localhost version

Rename input variable

Import re where needed and reformat

Reformat

Change env var to be yes / no, not True / False

Reformat

Pass list to urlunparse on Python 2

Specify port 8000

Use double quotes

Separate network tests and non-network tests into different steps

Trim whitespace

Try Network tests on all platforms

Print simplified localhost urls during Pytest network tests

Reorder pre-commit hooks and add blank line

Try curling from simplified url on Python2

Test curl from server only

Remove errant '

Run doctests against Python 2 SimpleHTTPServer

Special case "import shapefile" in doctests filter

Update shapefile.py

Always include first example doctest

Run Pytest tests in Python 2 non-slim container

Update action.yml

Update test_shapefile.py

Update test_shapefile.py

Explicitly export env var

Don't need to explicitly set env var.  Test without patching localhost.

Reformat

Update shapefile.py

Update shapefile.py

Use Caddy instead of SimpleHTTPServer

Run caddy in backgorund

Run all tests in all containers, all platforms, all Python versions

Revert to python -m http.server to avoid overloading Caddy releases page