### PR TITLE
Upgrade pre-commit repos and add ruff-check; add "dev" optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,20 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.4
+  rev: v0.12.7
   hooks:
+    # Run the linter
+    - id: ruff-check
+      args: [ --fix ]
+    # Run the formatter
     - id: ruff-format
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 6.0.1
   hooks:
     - id: isort
       name: isort (python)
       args: ["--profile", "black"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v5.0.0
   hooks:
     - id: check-yaml
     - id: trailing-whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = ["pyshp[test]", "pre-commit", "ruff"]
 test = ["pytest"]
 
 [project.urls]

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -41,7 +41,7 @@ def benchmark(
     time_taken = timeit.timeit(func, number=run_count)
     print("\b" * len(placeholder), end="")
     time_suffix = " s"
-    print(f"{time_taken:{col_widths[1]-len(time_suffix)}.3g}{time_suffix}", end="")
+    print(f"{time_taken:{col_widths[1] - len(time_suffix)}.3g}{time_suffix}", end="")
     print()
     return time_taken
 

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -1896,7 +1896,7 @@ class Reader:
                     # Close and delete the temporary zipfile
                     try:
                         zipfileobj.close()
-                    except:  # pylint: disable=bare-except
+                    except:  # pylint: disable=bare-except  # noqa: E722
                         pass
                     # Try to load shapefile
                     if self.shp or self.dbf:
@@ -3155,7 +3155,7 @@ class Writer:
         # Shape Type
         if self.shapeType is None and s.shapeType != NULL:
             self.shapeType = s.shapeType
-        if not s.shapeType in {NULL, self.shapeType}:
+        if s.shapeType not in {NULL, self.shapeType}:
             raise ShapefileException(
                 f"The shape's type ({s.shapeType}) must match "
                 f"the type of the shapefile ({self.shapeType})."


### PR DESCRIPTION
This PR does a few useful things:

- Update the pre-commit repos (via `pre-commit autoupdate`),
- Add [ruff check](https://docs.astral.sh/ruff/linter/);  this required modifying `noqa: E722` to ignore bare except
- Add a "dev" optional install, with some development tools. This allows (e.g.) `uv sync --all-extras` ([docs here](https://docs.astral.sh/uv/concepts/projects/sync/#syncing-development-dependencies)). In otherwords, it allows `pip install -e .[dev]` to install development tools as the optional/extra.