### PR TITLE
Python 3.0.0 alpha the last jedtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ and the bounding box area the shapefile covers:
 	>>> len(sf)
 	663
 	>>> sf.bbox
-	BBox(xmin=-122.515048, ymin=37.652916, xmax=-122.327622, ymax=37.863433)
+	(-122.515048, 37.652916, -122.327622, 37.863433)
 
 Finally, if you would prefer to work with the entire shapefile in a different
 format, you can convert all of it to a GeoJSON dictionary, although you may lose
@@ -1388,7 +1388,7 @@ Shapefiles containing M-values can be examined in several ways:
 	>>> r = shapefile.Reader('shapefiles/test/linem')
 
 	>>> r.mbox # the lower and upper bound of M-values in the shapefile
-	MBox(mmin=0.0, mmax=3.0)
+	(0.0, 3.0)
 
 	>>> r.shape(0).m # flat list of M-values
 	[0.0, None, 3.0, None, 0.0, None, None]
@@ -1421,7 +1421,7 @@ To examine a Z-type shapefile you can do:
 	>>> r = shapefile.Reader('shapefiles/test/linez')
 
 	>>> r.zbox # the lower and upper bound of Z-values in the shapefile
-	ZBox(zmin=0.0, zmax=22.0)
+	(0.0, 22.0)
 
 	>>> r.shape(0).z # flat list of Z-values
 	[18.0, 20.0, 22.0, 0.0, 0.0, 0.0, 0.0, 15.0, 13.0, 14.0]

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -1327,7 +1327,7 @@ class _HasM(_CanHaveBBox):
                 f"Failed to write measure extremes for record {i}. Expected floats"
             )
         try:
-            if hasattr(s, "m"):
+            if getattr(s, "m", False):
                 # if m values are stored in attribute
                 ms = [m if m is not None else NODATA for m in s.m]
 
@@ -1335,12 +1335,9 @@ class _HasM(_CanHaveBBox):
                 # if m values are stored as 3rd/4th dimension
                 # 0-index position of m value is 3 if z type (x,y,z,m), or 2 if m type (x,y,m)
                 mpos = 3 if s.shapeType in _HasZ._shapeTypes else 2
-                ms = []
-                for p in s.points:
-                    if len(p) > mpos and p[mpos] is not None:
-                        ms.append(p[mpos])
-                    else:
-                        ms.append(NODATA)
+                ms = [p[mpos] if len(p) > mpos and p[mpos] is not None else NODATA
+                      for p in s.points
+                     ]  
 
             num_bytes_written += b_io.write(pack(f"<{len(ms)}d", *ms))
 
@@ -1388,7 +1385,7 @@ class _HasZ(_CanHaveBBox):
                 f"Failed to write elevation extremes for record {i}. Expected floats."
             )
         try:
-            if hasattr(s, "z"):
+            if getattr(s, "z", False):
                 # if z values are stored in attribute
                 zs = s.z
             else:
@@ -1444,16 +1441,13 @@ class PointM(Point):
         # Write a single M value
         # Note: missing m values are autoset to NODATA.
 
-        if hasattr(s, "m"):
+        if hasattr(s, "m", False):
             # if m values are stored in attribute
             try:
                 # if not s.m or s.m[0] is None:
                 #     s.m = (NODATA,)
                 # m = s.m[0]
-                if s.m and s.m[0] is not None:
-                    m = s.m[0]
-                else:
-                    m = NODATA
+                m = s.m[0] if s.m and s.m[0] is not None else NODATA                    
             except error:
                 raise ShapefileException(
                     f"Failed to write measure value for record {i}. Expected floats."

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -1292,7 +1292,7 @@ class _HasM(_CanHaveBBox):
     m: Sequence[Optional[float]]
 
     def __init__(self, *args, **kwargs):
-        self.z = []
+        self.m = []
         super().__init__(*args, **kwargs)
 
     def _set_ms_from_byte_stream(

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -1291,6 +1291,10 @@ class _HasM(_CanHaveBBox):
     )
     m: Sequence[Optional[float]]
 
+    def __init__(self, *args, **kwargs):
+        self.z = []
+        super().__init__(*args, **kwargs)
+
     def _set_ms_from_byte_stream(
         self, b_io: ReadSeekableBinStream, nPoints: int, next_shape: int
     ):
@@ -1359,6 +1363,10 @@ class _HasZ(_CanHaveBBox):
         ]
     )
     z: Sequence[float]
+
+    def __init__(self, *args, **kwargs):
+        self.z = []
+        super().__init__(*args, **kwargs)
 
     def _set_zs_from_byte_stream(self, b_io: ReadableBinStream, nPoints: int):
         __zmin, __zmax = unpack("<2d", b_io.read(16))  # pylint: disable=unused-private-member

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -2538,7 +2538,7 @@ class Reader:
         # parse each value
         record = []
         for (__name, typ, __size, decimal), value in zip(fieldTuples, recordContents):
-            if typ in {FieldType.N, FieldType.F}:
+            if typ is FieldType.N or typ is FieldType.F:
                 # numeric or float: number stored as a string, right justified, and padded with blanks to the width of the field.
                 value = value.split(b"\0")[0]
                 value = value.replace(b"*", b"")  # QGIS NULL is all '*' chars
@@ -3046,7 +3046,7 @@ class Writer:
         else:
             f.write(pack("<4d", 0, 0, 0, 0))
         # Elevation
-        if self.shapeType in {POINTZ} | _HasZ._shapeTypes:
+        if self.shapeType in PointZ._shapeTypes | _HasZ._shapeTypes:
             # Z values are present in Z type
             zbox = self.zbox()
             if zbox is None:
@@ -3056,7 +3056,7 @@ class Writer:
             # As per the ESRI shapefile spec, the zbox for non-Z type shapefiles are set to 0s
             zbox = ZBox(0, 0)
         # Measure
-        if self.shapeType in {POINTM, POINTZ} | _HasM._shapeTypes:
+        if self.shapeType in PointM._shapeTypes | _HasM._shapeTypes:
             # M values are present in M or Z type
             mbox = self.mbox()
             if mbox is None:
@@ -3155,7 +3155,7 @@ class Writer:
         # Shape Type
         if self.shapeType is None and s.shapeType != NULL:
             self.shapeType = s.shapeType
-        if s.shapeType not in {NULL, self.shapeType}:
+        if s.shapeType != NULL and s.shapeType != self.shapeType:
             raise ShapefileException(
                 f"The shape's type ({s.shapeType}) must match "
                 f"the type of the shapefile ({self.shapeType})."
@@ -3166,11 +3166,11 @@ class Writer:
         new_bbox = self.__bbox(s) if s.shapeType != NULL else None
         new_mbox = (
             self.__mbox(s)
-            if s.shapeType in {POINTM, POINTZ} | _HasM._shapeTypes
+            if s.shapeType in _PointM._shapeTypes | _HasM._shapeTypes
             else None
         )
         new_zbox = (
-            self.__zbox(s) if s.shapeType in {POINTZ} | _HasZ._shapeTypes else None
+            self.__zbox(s) if s.shapeType in _PointZ._shapeTypes | _HasZ._shapeTypes else None
         )
 
         # Create an in-memory binary buffer to avoid
@@ -3266,7 +3266,7 @@ class Writer:
     def _dbf_missing_placeholder(
         value: RecordValue, field_type: FieldType, size: int
     ) -> str:
-        if field_type in {FieldType.N, FieldType.F}:
+        if field_type is FieldType.N or field_type is FieldType.F:
             return "*" * size  # QGIS NULL
         if field_type is FieldType.D:
             return "0" * 8  # QGIS NULL for date type
@@ -3354,7 +3354,7 @@ class Writer:
 
             if value in MISSING:
                 str_val = self._dbf_missing_placeholder(value, type_, size)
-            elif type_ in {FieldType.N, FieldType.F}:
+            elif type_ is FieldType.N or type_ is FieldType.F:
                 str_val = self._try_coerce_to_numeric_str(value, size, decimal)
             elif type_ is FieldType.D:
                 str_val = self._try_coerce_to_date_str(value)

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -3155,7 +3155,7 @@ class Writer:
         # Shape Type
         if self.shapeType is None and s.shapeType != NULL:
             self.shapeType = s.shapeType
-        if s.shapeType != NULL and s.shapeType != self.shapeType:
+        if s.shapeType not in (NULL, self.shapeType):
             raise ShapefileException(
                 f"The shape's type ({s.shapeType}) must match "
                 f"the type of the shapefile ({self.shapeType})."

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -1218,11 +1218,11 @@ class Point(Shape):
         n = Point._write_x_y_to_byte_stream(b_io, x, y, i)
 
         # Write a single Z value
-        if s.shapeType == POINTZ:
+        if compatible_with(s, PointZ):
             n += PointZ._write_single_point_z_to_byte_stream(b_io, s, i)
 
         # Write a single M value
-        if s.shapeType in {POINTM, POINTZ}:
+        if compatible_with(s, PointM):
             n += PointM._write_single_point_m_to_byte_stream(b_io, s, i)
 
         return n

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -19,7 +19,6 @@ import sys
 import tempfile
 import time
 import zipfile
-from collections.abc import Hashable
 from datetime import date
 from struct import Struct, calcsize, error, pack, unpack
 from typing import (
@@ -183,7 +182,7 @@ FieldTypeT = Literal["C", "D", "F", "L", "M", "N"]
 class FieldType:
     """A bare bones 'enum', as the enum library noticeably slows performance."""
 
-    # __slots__ = ["C", "D", "F", "L", "M", "N", "__members__", "raise_if_invalid", "is_numeric"]
+    # __slots__ = ["C", "D", "F", "L", "M", "N", "__members__"]
 
     C: Final = "C"  # "Character"  # (str)
     D: Final = "D"  # "Date"
@@ -200,6 +199,11 @@ class FieldType:
         "N",
     }  # set(__slots__) - {"__members__"}
 
+    # def raise_if_invalid(field_type: Hashable):
+    #     if field_type not in FieldType.__members__:
+    #         raise ShapefileException(
+    #             f"field_type must be in {{FieldType.__members__}}. Got: {field_type=}. "
+    #         )
 
 
 FIELD_TYPE_ALIASES: dict[Union[str, bytes], FieldTypeT] = {}
@@ -210,7 +214,7 @@ for c in FieldType.__members__:
     FIELD_TYPE_ALIASES[c.encode("ascii").upper()] = c
 
 
-
+# Use functional syntax to have an attribute named type, a Python keyword
 class Field(NamedTuple):
     name: str
     field_type: FieldTypeT
@@ -2569,7 +2573,7 @@ class Reader:
         # parse each value
         record = []
         for (__name, typ, __size, decimal), value in zip(fieldTuples, recordContents):
-            if FieldType.is_numeric(typ):
+            if typ is FieldType.N or typ is FieldType.F:
                 # numeric or float: number stored as a string, right justified, and padded with blanks to the width of the field.
                 value = value.split(b"\0")[0]
                 value = value.replace(b"*", b"")  # QGIS NULL is all '*' chars
@@ -2595,7 +2599,7 @@ class Reader:
                         except ValueError:
                             # not parseable as int, set to None
                             value = None
-            elif typ == FieldType.D:
+            elif typ is FieldType.D:
                 # date: 8 bytes - date stored as a string in the format YYYYMMDD.
                 if (
                     not value.replace(b"\x00", b"")
@@ -2613,7 +2617,7 @@ class Reader:
                     except (TypeError, ValueError):
                         # if invalid date, just return as unicode string so user can decimalde
                         value = str(value.strip())
-            elif typ == FieldType.L:
+            elif typ is FieldType.L:
                 # logical: 1 byte - initialized to 0x20 (space) otherwise T or F.
                 if value == b" ":
                     value = None  # space means missing or not yet set
@@ -3325,8 +3329,6 @@ class Writer:
             # fieldName, fieldType, size and deci were already checked
             # when their Field instance was created and added to self.fields
             str_val: Optional[str] = None
-
-
 
             if fieldType in ("N", "F"):
                 # numeric or float: number stored as a string, right justified, and padded with blanks to the width of the field.

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -3166,11 +3166,13 @@ class Writer:
         new_bbox = self.__bbox(s) if s.shapeType != NULL else None
         new_mbox = (
             self.__mbox(s)
-            if s.shapeType in _PointM._shapeTypes | _HasM._shapeTypes
+            if s.shapeType in PointM._shapeTypes | _HasM._shapeTypes
             else None
         )
         new_zbox = (
-            self.__zbox(s) if s.shapeType in _PointZ._shapeTypes | _HasZ._shapeTypes else None
+            self.__zbox(s)
+            if s.shapeType in PointZ._shapeTypes | _HasZ._shapeTypes
+            else None
         )
 
         # Create an in-memory binary buffer to avoid

--- a/test_shapefile.py
+++ b/test_shapefile.py
@@ -695,7 +695,7 @@ def test_reader_fields():
 
         field = fields[0]
         assert isinstance(field[0], str)  # field name
-        assert field[1].name in ["C", "N", "F", "L", "D", "M"]  # field type
+        assert field[1] in ["C", "N", "F", "L", "D", "M"]  # field type
         assert isinstance(field[2], int)  # field length
         assert isinstance(field[3], int)  # decimal length
 


### PR DESCRIPTION
Restore the performance level to that before the refactor of the dbf record writer methods.  Correct the implementations of shape bbox, mbox and zbox calculations.