### PR TITLE
Replace isort with ruff check "I" rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
       args: [ --fix ]
     # Run the formatter
     - id: ruff-format
-- repo: https://github.com/pycqa/isort
-  rev: 6.0.1
-  hooks:
-    - id: isort
-      name: isort (python)
-      args: ["--profile", "black"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,12 +87,14 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.9
-target-version = "py39"
-
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F"]
+select = [
+    "E4",  # pycodestyle: Import
+    "E7",  # pycodestyle: Statement
+    "E9",  # pycodestyle: Runtime
+    "F",   # pyflakes
+    "I",   # isort
+]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
This replaces isort with ruff check's ["I" rule](https://docs.astral.sh/ruff/rules/#isort-i).

Also, small nits:

- Remove [`tool.ruff.target-version`](https://docs.astral.sh/ruff/settings/#target-version) since it is recommended to use `project.requires-python` instead, which is already [defined](https://github.com/GeospatialPython/pyshp/blob/f083ee8c2c1ea3fde2e3bab9c9748dbd982c40ed/pyproject.toml#L19)
- Expand `tool.ruff.lint.select` with inline comments to describe each rule selected