### PR TITLE
Enable Ruff pyupgrade (UP) rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ select = [
     "E9",  # pycodestyle: Runtime
     "F",   # pyflakes
     "I",   # isort
+    "UP",  # pyupgrade
 ]
 ignore = []
 

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -6,11 +6,11 @@ import collections
 import functools
 import os
 import timeit
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryFile as TempF
-from typing import Iterable, Union, cast
+from typing import cast
 
 import shapefile
 
@@ -51,14 +51,14 @@ fields = {}
 shapeRecords = collections.defaultdict(list)
 
 
-def open_shapefile_with_PyShp(target: Union[str, PathLike]):
+def open_shapefile_with_PyShp(target: str | PathLike):
     with shapefile.Reader(target) as r:
         fields[target] = r.fields
         for shapeRecord in r.iterShapeRecords():
             shapeRecords[target].append(shapeRecord)
 
 
-def write_shapefile_with_PyShp(target: Union[str, PathLike]):
+def write_shapefile_with_PyShp(target: str | PathLike):
     with TempF("wb") as shp, TempF("wb") as dbf, TempF("wb") as shx:
         with shapefile.Writer(shp=shp, dbf=dbf, shx=shx) as w:  # type: ignore [arg-type]
             for field_info_tuple in fields[target]:

--- a/test_shapefile.py
+++ b/test_shapefile.py
@@ -493,7 +493,7 @@ def test_reader_url():
 
         def Reader(url):
             new_url = shapefile._replace_remote_url(url)
-            print("repr(new_url): %s" % repr(new_url))
+            print(f"repr(new_url): {repr(new_url)}")
             return shapefile.Reader(new_url)
     else:
         print("Using plain Reader")


### PR DESCRIPTION
This enables Ruff's [pyupgrade (UP)](https://docs.astral.sh/ruff/rules/#pyupgrade-up) rule.

The associated fixes are automated (no manual edits) and are either [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/#non-pep604-annotation-union-up007) or [UP045](https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional/#non-pep604-annotation-optional-up045).