### PR TITLE
Fix UnboundLocalError when reading byte_stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ part of your geospatial project.
 
 # Version Changes
 
-## Next
+
+## 3.0.3.dev
+### Bug fix
+- Prevented UnboundLocalError when reading non-single point M and Z type Shapefiles (@ekawas-vrify).
 
 ### Testing.
-- Test PyShp on the Python 3.14 official release (officially released this week, no longer in beta)
+- Test PyShp on the Python 3.14 official release (officially released this week, no longer in beta).
 
 ## 3.0.2
 
@@ -1572,6 +1575,7 @@ Casey Meisenzahl
 Charles Arnold
 David A. Riggs
 davidh-ssec
+Edward Kawas
 Evan Heidtmann
 ezcitron
 fiveham

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
-VERSION NEXT
+VERSION 3.0.3.dev
+
+2025-10-25
+	Bug fix:
+	* Prevented UnboundLocalError when reading non-single point M and Z type Shapefiles (@ekawas-vrify).
 
 2025-10-10
 	Testing:

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -8,7 +8,7 @@ Compatible with Python versions >=3.9
 
 from __future__ import annotations
 
-__version__ = "3.0.3.dev0"
+__version__ = "3.0.3.dev"
 
 import array
 import doctest


### PR DESCRIPTION
The variable mbox is only assigned `if next_shape - b_io.tell() >= 16`. 

If that condition is not met, mbox is never assigned, but the function always tries to return `mbox, ms`, which will raise `UnboundLocalError` if mbox was never set.

2 ways to deal with this:

- Raising an exception with a clear message, or
- Assigning a default value to mbox

I chose to assign None to the variable but I am not sure if this makes sense.