### PR TITLE
Use dependency groups for dev and test (PEP 735)

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -76,8 +76,9 @@ runs:
       shell: bash
       working-directory: dist/
       run: |
+        python -m pip install --upgrade pip
         WHEEL_NAME=$(ls pyshp-*py3-none-any.whl)
-        python -m pip install $WHEEL_NAME[test]
+        python -m pip install $WHEEL_NAME --group ../Pyshp/pyproject.toml:test
 
     - name: Doctests
       shell: bash

--- a/.github/workflows/speed_test.yml
+++ b/.github/workflows/speed_test.yml
@@ -44,18 +44,17 @@ jobs:
         name: PyShp_wheel_and_sdist
         path: dist
 
-    - name: Install PyShp + test deps from the wheel (downloaded in prev step)
-      shell: bash
-      working-directory: dist/
-      run: |
-        WHEEL_NAME=$(ls pyshp-*py3-none-any.whl)
-        python -m pip install $WHEEL_NAME[test]
-
     - uses: actions/checkout@v6
       with:
         path: ./Pyshp
 
-
+    - name: Install PyShp + test deps from the wheel (downloaded in prev step)
+      shell: bash
+      working-directory: dist/
+      run: |
+        python -m pip install --upgrade pip
+        WHEEL_NAME=$(ls pyshp-*py3-none-any.whl)
+        python -m pip install $WHEEL_NAME --group ../Pyshp/pyproject.toml:test
 
     - name: Checkout shapefiles and zip file artefacts repo
       uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ part of your geospatial project.
 
 # Version Changes
 
+## 3.0.5
+
+### Project structure:
+ - Use dependency groups for dev and test instead of optional-dependencies in pyproject.toml ([Mike Toews](https://github.com/mwtoews))
+
+
 ## 3.0.4
 
 ### Type checking

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+VERSION 3.0.5
+
+2026-05-18
+	Project structure:
+	* Use dependency groups for dev and test instead of optional-dependencies in pyproject.toml (Mike Toews)
+
 VERSION 3.0.4
 
 2026-05-17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,23 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-]
 
 [project.optional-dependencies]
-dev = ["pyshp[test]", "pre-commit", "ruff"]
-test = ["pytest"]
 stubs=["pyshp-stubs"]
+
+[dependency-groups]
+dev = [
+    {include-group = "lint"},
+    {include-group = "test"}
+]
+lint = [
+    "mypy",
+    "pre-commit",
+    "ruff",
+]
+test = [
+    "pytest",
+]
 
 [project.urls]
 Repository = "https://github.com/GeospatialPython/pyshp"

--- a/src/shapefile.py
+++ b/src/shapefile.py
@@ -8,7 +8,7 @@ Compatible with Python versions >=3.9
 
 from __future__ import annotations
 
-__version__ = "3.0.4"
+__version__ = "3.0.5"
 
 import array
 import doctest


### PR DESCRIPTION
This uses [PEP 735](https://peps.python.org/pep-0735/) (also [described here](https://packaging.python.org/en/latest/specifications/dependency-groups/)) to provide internal development dependencies. These are moved from the optional dependencies.  It also adds a `lint` group.

This feature requires recent versions of pip, and works like this for the `dev` group:

    $ python -m pip install -e . --group dev
 
Or if the repo is installed to a different directory, specify the path to the `pyproject.toml` file:

    $ python -m pip install ./dist/pyshp-3.0.4-py3-none-any.whl --group ./Pyshp/pyproject.toml:dev

Other tools like `uv` [already include `dev` by default](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups).